### PR TITLE
SYS-1569: Upgrade bookops_worldcat package from 0.5.0 to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,11 @@ are installed in the container.
    # Open a Python shell in the container
    $ docker-compose exec batchcd python
    
-   # Run the program (TODO: Update program name(s))
-   $ docker-compose exec batchcd python search_worldcat.py batch_016_20240229.tsv
+   # Run the program against a full file of data
+   $ docker-compose exec batchcd python make_music_records.py batch_016_20240229.tsv
+
+   # Run the program against a file of data, starting with record 5 and ending with record 10
+   $ docker-compose exec batchcd python make_music_records.py -s 5 -e 10 batch_016_20240229.tsv
    ```
 4. Some data sources require API keys. Get a copy of `api_keys.py` from a teammate and put it in the top level directory of the project.
 

--- a/data_evaluator.py
+++ b/data_evaluator.py
@@ -64,7 +64,7 @@ def any_record_has_clu(client: WorldcatClient, records: list[Record]) -> bool:
     """
     for record in records:
         oclc_number = get_oclc_number(record)
-        if client.is_held_by(oclc_number, oclc_symbol="CLU"):
+        if client.is_held_by_us(oclc_number):
             print(f"\tREJECTING ALL RECORDS: OCLC {oclc_number} is held by CLU")
             print(f"\tWorldcat Title -> {record.title}")
             return True

--- a/make_music_records.py
+++ b/make_music_records.py
@@ -41,7 +41,9 @@ def main() -> None:
     # Initialize the clients used for searching various data sources.
     worldcat_client, discogs_client, musicbrainz_client = get_clients()
 
-    for idx, row in enumerate(music_data[args.start_index : args.end_index], start=1):
+    for idx, row in enumerate(
+        music_data[args.start_index : args.end_index], start=args.start_index
+    ):
         print(f"Starting row {idx}")
         upc_code, call_number, barcode, official_title = get_next_data_row(row)
         print(f"{call_number}: Searching for {upc_code} ({official_title})")

--- a/make_music_records.py
+++ b/make_music_records.py
@@ -126,8 +126,6 @@ def get_clients() -> tuple[WorldcatClient, DiscogsClient, MusicbrainzClient]:
     worldcat_client = WorldcatClient(
         api_keys.WORLDCAT_METADATA_CLIENT_ID,
         api_keys.WORLDCAT_METADATA_CLIENT_SECRET,
-        api_keys.WORLDCAT_PRINCIPAL_ID,
-        api_keys.WORLDCAT_PRINCIPAL_IDNS,
     )
     discogs_client = DiscogsClient(api_keys.DISCOGS_USER_TOKEN)
     musicbrainz_client = MusicbrainzClient()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # For OCLC Worldcat Metadata API support
-bookops-worldcat==0.5.0
+bookops-worldcat==1.0.0
 # For Discogs
 python3-discogs-client==2.7
 # For Musicbrainz

--- a/tests/test_search_worldcat.py
+++ b/tests/test_search_worldcat.py
@@ -10,8 +10,6 @@ class TestSearchWorldcat(unittest.TestCase):
         cls.worldcat_client = WorldcatClient(
             "fake_client_id",
             "fake_client_secret",
-            "fake_principal_id",
-            "fake_principal_idns",
         )
         # Load sample data for use by all tests.
         # Dict of dicts, keyed on UPC code, with real (as of 2024-03-12) response data.
@@ -36,8 +34,6 @@ class TestMarcXmlConversion(unittest.TestCase):
         cls.worldcat_client = WorldcatClient(
             "fake_client_id",
             "fake_client_secret",
-            "fake_principal_id",
-            "fake_principal_idns",
         )
 
     def test_xml_to_binary_marc(self):


### PR DESCRIPTION
Implements [SYS-1569](https://uclalibrary.atlassian.net/browse/SYS-1569).

This PR implements changes required by the move from version 0.5.0 to 1.0.0 of the `bookops_worldcat` package.  Internally, the package removed use of deprecated Worldcat Metadata 1.0 and 1.1 APIs and moved to Metadata 2.0 APIs.  Breaking changes include:
* Authorization (several parameters changed or removed)
* API methods (renamed for consistency, changes to parameters and returned data)
* Details: https://bookops-cat.github.io/bookops-worldcat/latest/changelog/

#### Testing

None of our tests changed, other than removing some no-longer-supported fake values for initialization.  We don't have full integration tests for this project, but the package itself has a full test suite which I trust.

For local testing:
```
# Start (or restart) the application, rebuilding the container
docker-compose up -d --build

# Run the tests we do have, to confirm all 12 still pass
docker-compose exec batchcd python -m unittest discover -s tests

# Run the program against a few records, make sure nothing blows up
docker-compose exec batchcd python make_music_records.py -e 5 batch_016_20240229.tsv
```




[SYS-1569]: https://uclalibrary.atlassian.net/browse/SYS-1569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ