### PR TITLE
SYS-1559: Add local fields to Worldcat MARC records

### DIFF
--- a/make_music_records.py
+++ b/make_music_records.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import api_keys
 import argparse
 from csv import DictReader
@@ -11,6 +12,7 @@ from data_evaluator import (
     get_unique_titles,
     get_usable_worldcat_records,
 )
+from create_marc_record import add_local_fields, write_marc_record
 from searchers.discogs import DiscogsClient
 from searchers.musicbrainz import MusicbrainzClient
 from searchers.worldcat import WorldcatClient
@@ -36,7 +38,13 @@ def main() -> None:
     args = parser.parse_args()
 
     # Get the set of data provided by Music library to use for this process.
-    music_data = get_dicts_from_tsv(args.music_data_file)
+    input_filename = args.music_data_file
+    music_data = get_dicts_from_tsv(input_filename)
+
+    # Get the names of the files where MARC records will be written.
+    worldcat_record_filename = get_marc_filename(input_filename, "oclc")
+    # TODO
+    # original_record_filename = get_marc_filename(input_filename, "orig")
 
     # Initialize the clients used for searching various data sources.
     worldcat_client, discogs_client, musicbrainz_client = get_clients()
@@ -97,9 +105,12 @@ def main() -> None:
         marc_record = get_best_worldcat_record(usable_records)
         if marc_record:
             print(f"\tWinner: OCLC# {get_oclc_number(marc_record)}")
-            # TODO: Enhance marc_record with local fields
+            marc_record = add_local_fields(marc_record, barcode, call_number)
+            write_marc_record(marc_record, filename=worldcat_record_filename)
         else:
             # TODO: Create minimal MARC record from Discogs/Musicbrainz data
+            # marc_record = "TODO"
+            # write_marc_record(marc_record, filename=original_record_filename)
             pass
 
         print(f"Finished row {idx}\n")
@@ -144,6 +155,14 @@ def get_next_data_row(row: dict) -> tuple[str, str, str, str]:
     barcode = row["barcode"].strip().upper()
     official_title = row["title"].strip()
     return upc_code, call_number, barcode, official_title
+
+
+def get_marc_filename(input_filename: str, file_type: str) -> str:
+    """Get the name of the file where MARC records of the given type
+    will be written, based on the input filename.
+    """
+    base = Path(input_filename).stem
+    return f"{base}_{file_type}.mrc"
 
 
 if __name__ == "__main__":

--- a/tests/test_marc_creation.py
+++ b/tests/test_marc_creation.py
@@ -1,5 +1,7 @@
 import unittest
-from create_marc_record import create_base_record
+
+from pymarc import Subfield
+from create_marc_record import add_local_fields, create_base_record
 
 
 class TestBaseRecord(unittest.TestCase):
@@ -19,3 +21,28 @@ class TestBaseRecord(unittest.TestCase):
     def test_fld344_repeated(self):
         fld344s = self.base_record.get_fields("344")
         self.assertEqual(len(fld344s), 2)
+
+
+class TestLocalFields(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Create simulated record for use in all tests in this class.
+        base_record = create_base_record()
+        cls.record = add_local_fields(
+            base_record, barcode="FAKE BARCODE", call_number="FAKE CALL NUMBER"
+        )
+
+    def test_barcode_is_added(self):
+        fld049 = self.record.get("049")
+        expected_subfields = [
+            Subfield(code="a", value="CLUV"),
+            Subfield(code="l", value="FAKE BARCODE"),
+        ]
+        self.assertEqual(fld049.subfields, expected_subfields)
+
+    def test_call_number_is_added(self):
+        fld049 = self.record.get("099")
+        expected_subfields = [
+            Subfield(code="a", value="FAKE CALL NUMBER"),
+        ]
+        self.assertEqual(fld049.subfields, expected_subfields)


### PR DESCRIPTION
Implements [SYS-1559](https://uclalibrary.atlassian.net/browse/SYS-1559).

This PR adds `add_local_fields()`, a method which adds so-called "local fields" (049, 099,. 962, 966) with UCLA-specific data to a MARC record.  These fields are added to records from Worldcat as well as original records created from Discogs or MusicBrainz data.

I removed these fields from `create_base_record()`, since they need to go into all records.  The barcode and call number from the input file are added to 049 and 099 respectively, and the current date is set in the 962 $c.

There's also a new method, `write_marc_record()`, which appends the given MARC record in binary format to the specified file.  A new utility method `get_marc_filename()` in the main script determines the name of the file a record should go into, depending on the source of the data for that record.

Finally, a few new tests confirm that the correct fields with barcode and call number are created.


[SYS-1559]: https://uclalibrary.atlassian.net/browse/SYS-1559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ