### PR TITLE
SYS-1560: add MARC data from Discogs

### DIFF
--- a/create_marc_record.py
+++ b/create_marc_record.py
@@ -150,6 +150,161 @@ def add_local_fields(record: Record, barcode: str, call_number: str) -> Record:
     return record
 
 
+def add_discogs_data(base_record: Record, data: dict) -> Record:
+    # Dates (008/07-10) - release year
+    year = str(data["full_json"]["year"])  # make a string for later concatenation
+    current_008 = base_record.get_fields("008")[0].data
+    year_008 = current_008[:7] + year + current_008[11:]
+
+    # Lang (008/35-37) - zxx
+    new_008 = year_008[:35] + "zxx" + year_008[38:]
+    base_record.remove_fields("008")
+    base_record.add_field(Field(tag="008", data=new_008))
+
+    # 024 8# $a IDENTIFIERS\VALUE (only for type: Barcode)
+    # If no barcode element, do not include field.
+    if data["full_json"]["identifiers"]:
+        for identifier in data["full_json"]["identifiers"]:
+            # include only barcode elements without description: Text.
+            if identifier["type"] == "Barcode" and identifier["description"] != "Text":
+                # Normalize by removing spaces from value
+                value = identifier["value"].replace(" ", "")
+                subfields_024 = [Subfield("a", value)]
+                field_024 = Field(
+                    tag="024", indicators=["8", " "], subfields=subfields_024
+                )
+                base_record.add_field(field_024)
+
+    # 028 02 $a LABELS\CATNO $b LABELS\NAME
+    # If no labels\catno element, do not include field.
+    if data["full_json"]["labels"]:
+        for label in data["full_json"]["labels"]:
+            # If there are multiple labels\catno elements, create multiple 028 fields.
+            # If no labels\name element, do not include $b.
+            if "name" not in label:
+                subfields_028 = [Subfield("a", label["catno"])]
+            else:
+                subfields_028 = [
+                    Subfield("a", label["catno"]),
+                    Subfield("b", label["name"]),
+                ]
+            field_028 = Field(tag="028", indicators=["0", "2"], subfields=subfields_028)
+            base_record.add_field(field_028)
+
+    # 245 00 $a TITLE / $c ARTISTS\NAME
+    title_245 = data["title"]
+    # first artist only
+    if "artist" in data:
+        artist_245 = data["artist"]
+        # format: $a Title <space> <slash> $c Artists\name <period>
+        subfields_245 = [
+            Subfield("a", title_245 + " /"),
+            Subfield("c", artist_245 + "."),
+        ]
+    else:
+        # format: $a Title <period>
+        subfields_245 = [Subfield("a", title_245 + ".")]
+    # if the first word of the title=”the” then 2nd indicator=4.
+    # if the first word of the title=”a” then 2nd indicator=2.
+    if title_245.lower().startswith("the "):
+        field_245 = Field(tag="245", indicators=["0", "4"], subfields=subfields_245)
+    elif title_245.lower().startswith("a "):
+        field_245 = Field(tag="245", indicators=["0", "2"], subfields=subfields_245)
+    elif title_245.lower().startswith("an "):
+        field_245 = Field(tag="245", indicators=["0", "3"], subfields=subfields_245)
+    else:
+        field_245 = Field(tag="245", indicators=["0", "0"], subfields=subfields_245)
+    base_record.add_field(field_245)
+
+    # 264 #1 $a [Place of publication not identified] : $b LABELS\NAME, $c [RELEASED]
+    # For DATE - 1st 4 digits only
+    # If no label-info\label\name element, fill in $b with “[publisher not identified]”
+    # If there are multiple label-info\label\name elements, take only the first instance.
+    # If no date element, fill in $c with “[date of publication not identified]”
+
+    date_264 = str(data["full_json"]["year"])  # make a string for later concatenation
+    if data["full_json"]["labels"]:
+        label = data["full_json"]["labels"][0]
+        if "name" in label:
+            publisher = label["name"]
+        else:
+            publisher = "[publisher not identified]"
+    else:
+        publisher = "[publisher not identified]"
+
+    # format: [Place of publication not identified] <space> <colon>$b  LABELS\NAME <comma> $c <open square bracket>RELEASED<closed square bracket>
+    subfields_264 = [
+        Subfield("a", "[Place of publication not identified] :"),
+        Subfield("b", publisher + ","),
+        Subfield("c", "[" + date_264 + "]"),
+    ]
+    field_264 = Field(tag="264", indicators=[" ", "1"], subfields=subfields_264)
+    base_record.add_field(field_264)
+
+    # 300 ## $a FORMATS\QTY audio disc : $b digital ; $c 4 3/4 in.
+    # IF FORMATS\QTY>1, THEN $a FORMATS\QTY audio discs : $b digital ; $c 4 3/4 in.
+    # If no formats\qty element, or if formats\qty=0, fill in with “1.”
+
+    if data["full_json"]["formats"]:
+        qty = data["full_json"]["formats"][0]["qty"]
+    if not qty or qty == "0":
+        qty = "1"
+    if int(qty) > 1:
+        qty_text = qty + " audio discs :"
+    else:
+        qty_text = qty + " audio disc :"
+
+    # format: $a FORMATS\QTY audio disc <space> <colon> $b digital <space> <semicolon> $c 4 3/4 in.
+    subfields_300 = [
+        Subfield("a", qty_text),
+        Subfield("b", "digital ;"),
+        Subfield("c", "4 3/4 in."),
+    ]
+    field_300 = Field(tag="300", indicators=[" ", " "], subfields=subfields_300)
+    base_record.add_field(field_300)
+
+    # 500 ## $a Title from Discogs database.
+    # same as 245 $a
+    subfields_500 = [Subfield("a", title_245)]
+    field_500 = Field(tag="500", indicators=[" ", " "], subfields=subfields_500)
+    base_record.add_field(field_500)
+
+    # 505 0# $a TRACKLIST\TITLE -- $a TRACKLIST\TITLE -- $a TRACKLIST\TITLE […].
+    # If no tracklist element, do not include field.
+    if data["full_json"]["tracklist"]:
+        subfields_505 = []
+        # last $a is formatted differently
+        for track in data["full_json"]["tracklist"][:-1]:
+            # format:  $a TRACKLIST\TITLE <space> <hyphen> <hyphen> <space> TRACKLIST\TITLE<period>
+            track_title = track["title"]
+            subfields_505.append(Subfield("a", track_title + " --"))
+        # get last subfield and format
+        last_track_title = data["full_json"]["tracklist"][-1]["title"]
+        subfields_505.append(Subfield("a", last_track_title + "."))
+
+        field_505 = Field(tag="505", indicators=["0", " "], subfields=subfields_505)
+        base_record.add_field(field_505)
+
+    # 653 #6 $a GENRES
+    # include all genres in $a subfields
+    if data["full_json"]["genres"]:
+        subfields_653 = []
+        for genre in data["full_json"]["genres"]:
+            subfields_653.append(Subfield("a", genre))
+            field_653 = Field(tag="653", indicators=[" ", "6"], subfields=subfields_653)
+        base_record.add_field(field_653)
+
+    # 720 ## $a ARTISTS_SORT.
+    # single string fields with possible multiple artists
+    artist_720 = data["full_json"]["artists_sort"]
+    # format: $a ARTISTS_SORT.
+    subfields_720 = [Subfield("a", artist_720 + ".")]
+    field_720 = Field(tag="720", indicators=[" ", " "], subfields=subfields_720)
+    base_record.add_field(field_720)
+
+    return base_record
+
+
 def write_marc_record(record: Record, filename: str) -> None:
     """Write the record to a file in binary MARC format. Records are
     appended to the file.

--- a/create_marc_record.py
+++ b/create_marc_record.py
@@ -159,7 +159,7 @@ def add_discogs_data(base_record: Record, data: dict) -> Record:
     # Lang (008/35-37) - zxx
     new_008 = year_008[:35] + "zxx" + year_008[38:]
     base_record.remove_fields("008")
-    base_record.add_field(Field(tag="008", data=new_008))
+    base_record.add_ordered_field(Field(tag="008", data=new_008))
 
     # 024 8# $a IDENTIFIERS\VALUE (only for type: Barcode)
     # If no barcode element, do not include field.
@@ -173,7 +173,7 @@ def add_discogs_data(base_record: Record, data: dict) -> Record:
                 field_024 = Field(
                     tag="024", indicators=["8", " "], subfields=subfields_024
                 )
-                base_record.add_field(field_024)
+                base_record.add_ordered_field(field_024)
 
     # 028 02 $a LABELS\CATNO $b LABELS\NAME
     # If no labels\catno element, do not include field.
@@ -189,7 +189,7 @@ def add_discogs_data(base_record: Record, data: dict) -> Record:
                     Subfield("b", label["name"]),
                 ]
             field_028 = Field(tag="028", indicators=["0", "2"], subfields=subfields_028)
-            base_record.add_field(field_028)
+            base_record.add_ordered_field(field_028)
 
     # 245 00 $a TITLE / $c ARTISTS\NAME
     title_245 = data["title"]
@@ -214,7 +214,7 @@ def add_discogs_data(base_record: Record, data: dict) -> Record:
         field_245 = Field(tag="245", indicators=["0", "3"], subfields=subfields_245)
     else:
         field_245 = Field(tag="245", indicators=["0", "0"], subfields=subfields_245)
-    base_record.add_field(field_245)
+    base_record.add_ordered_field(field_245)
 
     # 264 #1 $a [Place of publication not identified] : $b LABELS\NAME, $c [RELEASED]
     # For DATE - 1st 4 digits only
@@ -239,7 +239,7 @@ def add_discogs_data(base_record: Record, data: dict) -> Record:
         Subfield("c", "[" + date_264 + "]"),
     ]
     field_264 = Field(tag="264", indicators=[" ", "1"], subfields=subfields_264)
-    base_record.add_field(field_264)
+    base_record.add_ordered_field(field_264)
 
     # 300 ## $a FORMATS\QTY audio disc : $b digital ; $c 4 3/4 in.
     # IF FORMATS\QTY>1, THEN $a FORMATS\QTY audio discs : $b digital ; $c 4 3/4 in.
@@ -261,13 +261,13 @@ def add_discogs_data(base_record: Record, data: dict) -> Record:
         Subfield("c", "4 3/4 in."),
     ]
     field_300 = Field(tag="300", indicators=[" ", " "], subfields=subfields_300)
-    base_record.add_field(field_300)
+    base_record.add_ordered_field(field_300)
 
     # 500 ## $a Title from Discogs database.
     # same as 245 $a
     subfields_500 = [Subfield("a", title_245)]
     field_500 = Field(tag="500", indicators=[" ", " "], subfields=subfields_500)
-    base_record.add_field(field_500)
+    base_record.add_ordered_field(field_500)
 
     # 505 0# $a TRACKLIST\TITLE -- $a TRACKLIST\TITLE -- $a TRACKLIST\TITLE […].
     # If no tracklist element, do not include field.
@@ -283,7 +283,7 @@ def add_discogs_data(base_record: Record, data: dict) -> Record:
         subfields_505.append(Subfield("a", last_track_title + "."))
 
         field_505 = Field(tag="505", indicators=["0", " "], subfields=subfields_505)
-        base_record.add_field(field_505)
+        base_record.add_ordered_field(field_505)
 
     # 653 #6 $a GENRES
     # include all genres in $a subfields
@@ -292,7 +292,7 @@ def add_discogs_data(base_record: Record, data: dict) -> Record:
         for genre in data["full_json"]["genres"]:
             subfields_653.append(Subfield("a", genre))
             field_653 = Field(tag="653", indicators=[" ", "6"], subfields=subfields_653)
-        base_record.add_field(field_653)
+        base_record.add_ordered_field(field_653)
 
     # 720 ## $a ARTISTS_SORT.
     # single string fields with possible multiple artists
@@ -300,7 +300,7 @@ def add_discogs_data(base_record: Record, data: dict) -> Record:
     # format: $a ARTISTS_SORT.
     subfields_720 = [Subfield("a", artist_720 + ".")]
     field_720 = Field(tag="720", indicators=[" ", " "], subfields=subfields_720)
-    base_record.add_field(field_720)
+    base_record.add_ordered_field(field_720)
 
     return base_record
 

--- a/tests/sample_data/formatted_discogs_sample.data
+++ b/tests/sample_data/formatted_discogs_sample.data
@@ -1,0 +1,460 @@
+{
+  "title": "Soliloquy For Lilith",
+  "artist": "Nurse With Wound",
+  "publisher_number": "UDX 092",
+  "full_json": {
+    "id": 193195,
+    "resource_url": "https://api.discogs.com/releases/193195",
+    "status": "Accepted",
+    "year": 2003,
+    "uri": "https://www.discogs.com/release/193195-Nurse-With-Wound-Soliloquy-For-Lilith",
+    "artists": [
+      {
+        "name": "Nurse With Wound",
+        "anv": "",
+        "join": "",
+        "role": "",
+        "tracks": "",
+        "id": 26101,
+        "resource_url": "https://api.discogs.com/artists/26101",
+        "thumbnail_url": "https://i.discogs.com/qcbrqcITulloadAYEt4Y9ILUj3CIQA75oECRq6SoIVY/rs:fit/g:sm/q:40/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9BLTI2MTAx/LTE0ODkyNzIwOTgt/NzcxNi5qcGVn.jpeg"
+      }
+    ],
+    "artists_sort": "Nurse With Wound",
+    "labels": [
+      {
+        "name": "United Dairies",
+        "catno": "UDX 092",
+        "entity_type": "1",
+        "entity_type_name": "Label",
+        "id": 8625,
+        "resource_url": "https://api.discogs.com/labels/8625",
+        "thumbnail_url": "https://i.discogs.com/8-Aj2LsNCzdvQ6ZR4fiIeyiRKJaFdKZokpbYYSyELR0/rs:fit/g:sm/q:40/h:111/w:83/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9MLTg2MjUt/MDAxLmpwZw.jpeg"
+      }
+    ],
+    "series": [],
+    "companies": [
+      {
+        "name": "The Shadow Factory",
+        "catno": "",
+        "entity_type": "23",
+        "entity_type_name": "Recorded At",
+        "id": 293518,
+        "resource_url": "https://api.discogs.com/labels/293518",
+        "thumbnail_url": ""
+      }
+    ],
+    "formats": [
+      {
+        "name": "CD",
+        "qty": "3",
+        "descriptions": [
+          "Album",
+          "Remastered"
+        ]
+      },
+      {
+        "name": "Box Set",
+        "qty": "1",
+        "descriptions": [
+          "Limited Edition"
+        ]
+      }
+    ],
+    "data_quality": "Correct",
+    "community": {
+      "have": 410,
+      "want": 237,
+      "rating": {
+        "count": 91,
+        "average": 4.57
+      },
+      "submitter": {
+        "username": "davidagbr",
+        "resource_url": "https://api.discogs.com/users/davidagbr"
+      },
+      "contributors": [
+        {
+          "username": "davidagbr",
+          "resource_url": "https://api.discogs.com/users/davidagbr"
+        },
+        {
+          "username": "xdefenestratorx",
+          "resource_url": "https://api.discogs.com/users/xdefenestratorx"
+        },
+        {
+          "username": "drij",
+          "resource_url": "https://api.discogs.com/users/drij"
+        },
+        {
+          "username": "md",
+          "resource_url": "https://api.discogs.com/users/md"
+        },
+        {
+          "username": "3silences33",
+          "resource_url": "https://api.discogs.com/users/3silences33"
+        },
+        {
+          "username": "vom",
+          "resource_url": "https://api.discogs.com/users/vom"
+        },
+        {
+          "username": "pkdickhead",
+          "resource_url": "https://api.discogs.com/users/pkdickhead"
+        },
+        {
+          "username": "fulcanelli",
+          "resource_url": "https://api.discogs.com/users/fulcanelli"
+        },
+        {
+          "username": "Lanciferion",
+          "resource_url": "https://api.discogs.com/users/Lanciferion"
+        },
+        {
+          "username": "vententin",
+          "resource_url": "https://api.discogs.com/users/vententin"
+        },
+        {
+          "username": "Kater_Murr",
+          "resource_url": "https://api.discogs.com/users/Kater_Murr"
+        }
+      ],
+      "data_quality": "Correct",
+      "status": "Accepted"
+    },
+    "format_quantity": 3,
+    "date_added": "2003-10-10T10:55:11-07:00",
+    "date_changed": "2013-12-11T00:53:42-08:00",
+    "num_for_sale": 8,
+    "lowest_price": 23,
+    "master_id": 57500,
+    "master_url": "https://api.discogs.com/masters/57500",
+    "title": "Soliloquy For Lilith",
+    "country": "UK",
+    "released": "2003",
+    "notes": "Released in a golden lettered box with discs in black and white illustrated card sleeves. Includes an insert.\r\n\r\nLimited edition reissue of the 1988 album, plus a CD of new material. \r\n\r\nFirst edition limited to 1000 copies.\r\n\r\nAll material for this edition was recorded at the Shadow Factory, May 1988.\r\n\r\nOur thanks to Electricity for making this recording possible.",
+    "released_formatted": "2003",
+    "identifiers": [
+      {
+        "type": "Barcode",
+        "value": "5021958414720",
+        "description": "Not indicated on the box"
+      },
+      {
+        "type": "Mastering SID Code",
+        "value": "IFPI LW60",
+        "description": "All Discs"
+      },
+      {
+        "type": "Mould SID Code",
+        "value": "IFPI 1F05",
+        "description": "All Discs"
+      },
+      {
+        "type": "Matrix / Runout",
+        "value": "UJ666 DISC 1 E00276-2",
+        "description": "Disc 1"
+      },
+      {
+        "type": "Matrix / Runout",
+        "value": "UJ666 DISC 2 E00277-1",
+        "description": "Disc 2"
+      },
+      {
+        "type": "Matrix / Runout",
+        "value": "UJ666 DISC 3 E00278-2",
+        "description": "Disc 3"
+      }
+    ],
+    "videos": [
+      {
+        "uri": "https://www.youtube.com/watch?v=QfqxQZMvid8",
+        "title": "Soliloquy for Lilith 1",
+        "description": "Provided to YouTube by The state51 Conspiracy\n\nSoliloquy for Lilith 1 · Nurse With Wound\n\nSoliloquy for Lilith\n\n℗ 2005 Jnana Records\n\nReleased on: 2005-01-01\n\nComposer: Steven Stapleton\n\nAuto-generated by YouTube.",
+        "duration": 0,
+        "embed": true
+      },
+      {
+        "uri": "https://www.youtube.com/watch?v=ZlcmGl1-UIg",
+        "title": "Soliloquy for Lilith 2",
+        "description": "Provided to YouTube by The state51 Conspiracy\n\nSoliloquy for Lilith 2 · Nurse With Wound\n\nSoliloquy for Lilith\n\n℗ 2005 Jnana Records\n\nReleased on: 2005-01-01\n\nComposer: Steven Stapleton\n\nAuto-generated by YouTube.",
+        "duration": 0,
+        "embed": true
+      },
+      {
+        "uri": "https://www.youtube.com/watch?v=Y00Vix3Z2WE",
+        "title": "Soliloquy for Lilith 3",
+        "description": "Provided to YouTube by The state51 Conspiracy\n\nSoliloquy for Lilith 3 · Nurse With Wound\n\nSoliloquy for Lilith\n\n℗ 2005 Jnana Records\n\nReleased on: 2005-01-01\n\nComposer: Steven Stapleton\n\nAuto-generated by YouTube.",
+        "duration": 0,
+        "embed": true
+      },
+      {
+        "uri": "https://www.youtube.com/watch?v=TqLby_79QoI",
+        "title": "Soliloquy for Lilith 4",
+        "description": "Provided to YouTube by The state51 Conspiracy\n\nSoliloquy for Lilith 4 · Nurse With Wound\n\nSoliloquy for Lilith\n\n℗ 2005 Jnana Records\n\nReleased on: 2005-01-01\n\nComposer: Steven Stapleton\n\nAuto-generated by YouTube.",
+        "duration": 0,
+        "embed": true
+      },
+      {
+        "uri": "https://www.youtube.com/watch?v=kle7XC5i8Oo",
+        "title": "Soliloquy for Lilith 5",
+        "description": "Provided to YouTube by The state51 Conspiracy\n\nSoliloquy for Lilith 5 · Nurse With Wound\n\nSoliloquy for Lilith\n\n℗ 2005 Jnana Records\n\nReleased on: 2005-01-01\n\nComposer: Steven Stapleton\n\nAuto-generated by YouTube.",
+        "duration": 0,
+        "embed": true
+      },
+      {
+        "uri": "https://www.youtube.com/watch?v=Q_rOYfWfDSs",
+        "title": "Soliloquy for Lilith 6",
+        "description": "Provided to YouTube by The state51 Conspiracy\n\nSoliloquy for Lilith 6 · Nurse With Wound\n\nSoliloquy for Lilith\n\n℗ 2005 Jnana Records\n\nReleased on: 2005-01-01\n\nComposer: Steven Stapleton\n\nAuto-generated by YouTube.",
+        "duration": 0,
+        "embed": true
+      },
+      {
+        "uri": "https://www.youtube.com/watch?v=DFDun-Q3mRA",
+        "title": "Soliloquy for Lilith 7",
+        "description": "Provided to YouTube by The state51 Conspiracy\n\nSoliloquy for Lilith 7 · Nurse With Wound\n\nSoliloquy for Lilith\n\n℗ 2005 Jnana Records\n\nReleased on: 2005-01-01\n\nComposer: Steven Stapleton\n\nAuto-generated by YouTube.",
+        "duration": 0,
+        "embed": true
+      },
+      {
+        "uri": "https://www.youtube.com/watch?v=weDrLjo_wWo",
+        "title": "Soliloquy for Lilith 8",
+        "description": "Provided to YouTube by The state51 Conspiracy\n\nSoliloquy for Lilith 8 · Nurse With Wound\n\nSoliloquy for Lilith\n\n℗ 2005 Jnana Records\n\nReleased on: 2005-01-01\n\nComposer: Steven Stapleton\n\nAuto-generated by YouTube.",
+        "duration": 0,
+        "embed": true
+      }
+    ],
+    "genres": [
+      "Electronic"
+    ],
+    "styles": [
+      "Abstract",
+      "Drone",
+      "Experimental"
+    ],
+    "tracklist": [
+      {
+        "position": "1-1",
+        "type_": "track",
+        "title": "Untitled",
+        "duration": "17:56"
+      },
+      {
+        "position": "1-2",
+        "type_": "track",
+        "title": "Untitled",
+        "duration": "17:06"
+      },
+      {
+        "position": "1-3",
+        "type_": "track",
+        "title": "Untitled",
+        "duration": "17:51"
+      },
+      {
+        "position": "2-1",
+        "type_": "track",
+        "title": "Untitled",
+        "duration": "17:51"
+      },
+      {
+        "position": "2-2",
+        "type_": "track",
+        "title": "Untitled",
+        "duration": "17:29"
+      },
+      {
+        "position": "2-3",
+        "type_": "track",
+        "title": "Untitled",
+        "duration": "17:30"
+      },
+      {
+        "position": "3-1",
+        "type_": "track",
+        "title": "Untitled",
+        "duration": "18:54"
+      },
+      {
+        "position": "3-2",
+        "type_": "track",
+        "title": "Untitled",
+        "duration": "20:52"
+      }
+    ],
+    "extraartists": [
+      {
+        "name": "Paul Jackson (13)",
+        "anv": "",
+        "join": "",
+        "role": "Artwork [Photoshop Work]",
+        "tracks": "",
+        "id": 1838264,
+        "resource_url": "https://api.discogs.com/artists/1838264"
+      },
+      {
+        "name": "Babs Santini",
+        "anv": "",
+        "join": "",
+        "role": "Design",
+        "tracks": "",
+        "id": 1084248,
+        "resource_url": "https://api.discogs.com/artists/1084248"
+      },
+      {
+        "name": "Dik (2)",
+        "anv": "",
+        "join": "",
+        "role": "Engineer",
+        "tracks": "",
+        "id": 752187,
+        "resource_url": "https://api.discogs.com/artists/752187"
+      },
+      {
+        "name": "Steven Stapleton",
+        "anv": "",
+        "join": "",
+        "role": "Mixed By",
+        "tracks": "",
+        "id": 185137,
+        "resource_url": "https://api.discogs.com/artists/185137"
+      },
+      {
+        "name": "Diana Rogerson",
+        "anv": "",
+        "join": "",
+        "role": "Recorded By",
+        "tracks": "",
+        "id": 84400,
+        "resource_url": "https://api.discogs.com/artists/84400"
+      },
+      {
+        "name": "Steven Stapleton",
+        "anv": "",
+        "join": "",
+        "role": "Recorded By",
+        "tracks": "",
+        "id": 185137,
+        "resource_url": "https://api.discogs.com/artists/185137"
+      },
+      {
+        "name": "Denis Blackham",
+        "anv": "",
+        "join": "",
+        "role": "Remastered By",
+        "tracks": "",
+        "id": 294328,
+        "resource_url": "https://api.discogs.com/artists/294328"
+      }
+    ],
+    "images": [
+      {
+        "type": "primary",
+        "uri": "https://i.discogs.com/A1GsN5z4rtq4dOU8cBGFh2B-oyXmT4Vywy1h0DcVd5Q/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMTYzOTQzODU3/LmpwZWc.jpeg",
+        "resource_url": "https://i.discogs.com/A1GsN5z4rtq4dOU8cBGFh2B-oyXmT4Vywy1h0DcVd5Q/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMTYzOTQzODU3/LmpwZWc.jpeg",
+        "uri150": "https://i.discogs.com/qI1SZbzdUzOgS1Wjb8c_lOt8v5S5WhbPbfYtTkHYKok/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMTYzOTQzODU3/LmpwZWc.jpeg",
+        "width": 600,
+        "height": 600
+      },
+      {
+        "type": "secondary",
+        "uri": "https://i.discogs.com/pzqwhoxRIBY2m0YqNS8R3uJknpjSR74ak40yO0FFU48/rs:fit/g:sm/q:90/h:52/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjI1/LTYyNTQuanBlZw.jpeg",
+        "resource_url": "https://i.discogs.com/pzqwhoxRIBY2m0YqNS8R3uJknpjSR74ak40yO0FFU48/rs:fit/g:sm/q:90/h:52/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjI1/LTYyNTQuanBlZw.jpeg",
+        "uri150": "https://i.discogs.com/1t9vgxYJ1tGM-ef4WMvthfhQljKPdnHTX3WhvFWlK88/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjI1/LTYyNTQuanBlZw.jpeg",
+        "width": 600,
+        "height": 52
+      },
+      {
+        "type": "secondary",
+        "uri": "https://i.discogs.com/sD6Lr50v9hk__ItH8HHkacJt9P2oH_hKt6w8-kH-dZI/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjQw/LTc4NTYuanBlZw.jpeg",
+        "resource_url": "https://i.discogs.com/sD6Lr50v9hk__ItH8HHkacJt9P2oH_hKt6w8-kH-dZI/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjQw/LTc4NTYuanBlZw.jpeg",
+        "uri150": "https://i.discogs.com/7Clha0TBXZyZx26I1G85BbwhYkN4UV2TnMedt3p9Kms/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjQw/LTc4NTYuanBlZw.jpeg",
+        "width": 600,
+        "height": 600
+      },
+      {
+        "type": "secondary",
+        "uri": "https://i.discogs.com/W3kCURCuQ637ycGHJUk5vESDxElXo_KUomnk9CMAaVE/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjQ2/LTUzNzYuanBlZw.jpeg",
+        "resource_url": "https://i.discogs.com/W3kCURCuQ637ycGHJUk5vESDxElXo_KUomnk9CMAaVE/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjQ2/LTUzNzYuanBlZw.jpeg",
+        "uri150": "https://i.discogs.com/Z0pSQ67rhe0e8edrXIvJ3RfJbDyKoFyV1479MPPDZ1s/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjQ2/LTUzNzYuanBlZw.jpeg",
+        "width": 600,
+        "height": 600
+      },
+      {
+        "type": "secondary",
+        "uri": "https://i.discogs.com/hi78doLs21ryEnD-zwCqCdKtDF7av0UbxwWIwdlQNtI/rs:fit/g:sm/q:90/h:601/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjUy/LTI3MTEuanBlZw.jpeg",
+        "resource_url": "https://i.discogs.com/hi78doLs21ryEnD-zwCqCdKtDF7av0UbxwWIwdlQNtI/rs:fit/g:sm/q:90/h:601/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjUy/LTI3MTEuanBlZw.jpeg",
+        "uri150": "https://i.discogs.com/WSUTZ5GWG2UQJBLLXoKilYCMFMNHGaA7wlQjBPfNRiU/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjUy/LTI3MTEuanBlZw.jpeg",
+        "width": 600,
+        "height": 601
+      },
+      {
+        "type": "secondary",
+        "uri": "https://i.discogs.com/2vW-o24kf1OrwTkW9-6U-GeYoHmU9M2XqTOjXLkHGeU/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjY2/LTIxMzQuanBlZw.jpeg",
+        "resource_url": "https://i.discogs.com/2vW-o24kf1OrwTkW9-6U-GeYoHmU9M2XqTOjXLkHGeU/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjY2/LTIxMzQuanBlZw.jpeg",
+        "uri150": "https://i.discogs.com/OVLSlpD-qm83pSeubynXraIddgmvRZaav3vmxQy7WPc/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjY2/LTIxMzQuanBlZw.jpeg",
+        "width": 600,
+        "height": 600
+      },
+      {
+        "type": "secondary",
+        "uri": "https://i.discogs.com/XB5hO58yIM2F3SxDf5Sk3jBlJiSNNy20Oks4ngxG8qY/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjcy/LTUxOTkuanBlZw.jpeg",
+        "resource_url": "https://i.discogs.com/XB5hO58yIM2F3SxDf5Sk3jBlJiSNNy20Oks4ngxG8qY/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjcy/LTUxOTkuanBlZw.jpeg",
+        "uri150": "https://i.discogs.com/GFgv9_38EWxA1oOC777aY8w2qeyaH0H__a1JBnxmVUQ/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjcy/LTUxOTkuanBlZw.jpeg",
+        "width": 600,
+        "height": 600
+      },
+      {
+        "type": "secondary",
+        "uri": "https://i.discogs.com/7N3UcdKa44Mgo9MOMAb3fgWw_dHE5ro2-i5KJpDGGGg/rs:fit/g:sm/q:90/h:599/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjc4/LTM2MTguanBlZw.jpeg",
+        "resource_url": "https://i.discogs.com/7N3UcdKa44Mgo9MOMAb3fgWw_dHE5ro2-i5KJpDGGGg/rs:fit/g:sm/q:90/h:599/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjc4/LTM2MTguanBlZw.jpeg",
+        "uri150": "https://i.discogs.com/PhUnH8jmh-nYR2_kxnBX8FaIXwzdk6ffXCIdc2dP9PE/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjc4/LTM2MTguanBlZw.jpeg",
+        "width": 600,
+        "height": 599
+      },
+      {
+        "type": "secondary",
+        "uri": "https://i.discogs.com/G1gxwqN8SRXOxv1VHvFt3BciDMXDX82OTjopyICIllU/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjg0/LTE5MDQuanBlZw.jpeg",
+        "resource_url": "https://i.discogs.com/G1gxwqN8SRXOxv1VHvFt3BciDMXDX82OTjopyICIllU/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjg0/LTE5MDQuanBlZw.jpeg",
+        "uri150": "https://i.discogs.com/yIf5ftb7gWM-VZVSKFpMKYAR9czaRxq1BGO16Q7-LIs/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjg0/LTE5MDQuanBlZw.jpeg",
+        "width": 600,
+        "height": 600
+      },
+      {
+        "type": "secondary",
+        "uri": "https://i.discogs.com/NeW9QYsVn_gMYLkaDOcsbcJSYUTEsZOU2wO9fJVgmbA/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjkx/LTMxMzMuanBlZw.jpeg",
+        "resource_url": "https://i.discogs.com/NeW9QYsVn_gMYLkaDOcsbcJSYUTEsZOU2wO9fJVgmbA/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjkx/LTMxMzMuanBlZw.jpeg",
+        "uri150": "https://i.discogs.com/FhlcJsCFXqcknDHhxKywBvrcx30hQhWLxX17S1GckYo/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjkx/LTMxMzMuanBlZw.jpeg",
+        "width": 600,
+        "height": 600
+      },
+      {
+        "type": "secondary",
+        "uri": "https://i.discogs.com/2adjnXEmPIy7P4MQVBz8kzQNd1BDS0Vro3NEfWGLAUA/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjk2/LTk3NjIuanBlZw.jpeg",
+        "resource_url": "https://i.discogs.com/2adjnXEmPIy7P4MQVBz8kzQNd1BDS0Vro3NEfWGLAUA/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjk2/LTk3NjIuanBlZw.jpeg",
+        "uri150": "https://i.discogs.com/7xTG2ygCM_FSB_-jZwxn9I-MlwHESQiwmcapXvfAgbk/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNjk2/LTk3NjIuanBlZw.jpeg",
+        "width": 600,
+        "height": 600
+      },
+      {
+        "type": "secondary",
+        "uri": "https://i.discogs.com/EtTMSuAIu0t3joZK-b2fEAAMUT6n-j_HdoAKlXvpdTQ/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNzAy/LTk2MjMuanBlZw.jpeg",
+        "resource_url": "https://i.discogs.com/EtTMSuAIu0t3joZK-b2fEAAMUT6n-j_HdoAKlXvpdTQ/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNzAy/LTk2MjMuanBlZw.jpeg",
+        "uri150": "https://i.discogs.com/EYXltLn5o0K53VE3kxXPPKf91pK7R6i1CkWArYUIqz0/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNzAy/LTk2MjMuanBlZw.jpeg",
+        "width": 600,
+        "height": 600
+      },
+      {
+        "type": "secondary",
+        "uri": "https://i.discogs.com/qrunmTDqMyC49ojstHKIU_2P09B0qtXykvWSWDVSWZc/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNzA3/LTQ4NDYuanBlZw.jpeg",
+        "resource_url": "https://i.discogs.com/qrunmTDqMyC49ojstHKIU_2P09B0qtXykvWSWDVSWZc/rs:fit/g:sm/q:90/h:600/w:600/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNzA3/LTQ4NDYuanBlZw.jpeg",
+        "uri150": "https://i.discogs.com/PXHyX5drtU7Hfri4Vt3JDfk98SxMzS_mZDM6YUZS0n4/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMzg2NzUxNzA3/LTQ4NDYuanBlZw.jpeg",
+        "width": 600,
+        "height": 600
+      }
+    ],
+    "thumb": "https://i.discogs.com/qI1SZbzdUzOgS1Wjb8c_lOt8v5S5WhbPbfYtTkHYKok/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTE5MzE5/NS0xMTYzOTQzODU3/LmpwZWc.jpeg",
+    "estimated_weight": 485,
+    "blocked_from_sale": false
+  }
+}

--- a/tests/test_marc_creation.py
+++ b/tests/test_marc_creation.py
@@ -1,7 +1,8 @@
 import unittest
+import json
 
 from pymarc import Subfield
-from create_marc_record import add_local_fields, create_base_record
+from create_marc_record import add_local_fields, create_base_record, add_discogs_data
 
 
 class TestBaseRecord(unittest.TestCase):
@@ -46,3 +47,80 @@ class TestLocalFields(unittest.TestCase):
             Subfield(code="a", value="FAKE CALL NUMBER"),
         ]
         self.assertEqual(fld049.subfields, expected_subfields)
+
+
+class TestDiscogsFields(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Create simulated record for use in all tests in this class.
+        base_record = create_base_record()
+        cls.record = add_local_fields(
+            base_record, barcode="FAKE BARCODE", call_number="FAKE CALL NUMBER"
+        )
+        with open("tests/sample_data/formatted_discogs_sample.data") as f:
+            data = json.load(f)
+        cls.record = add_discogs_data(cls.record, data)
+
+    def test_field_024(self):
+        fld024 = self.record.get("024")
+        # one barcode in the sample data
+        expected_subfields = [
+            Subfield(code="a", value="5021958414720"),
+        ]
+        self.assertEqual(fld024.subfields, expected_subfields)
+
+    def test_field_028(self):
+        fld028 = self.record.get("028")
+        self.assertEqual(fld028.subfields[0].code, "a")
+        self.assertEqual(fld028.subfields[0].value, "UDX 092")
+        self.assertEqual(fld028.subfields[1].code, "b")
+        self.assertEqual(fld028.subfields[1].value, "United Dairies")
+
+    def test_field_245(self):
+        fld245 = self.record.get("245")
+        self.assertEqual(fld245.subfields[0].code, "a")
+        self.assertEqual(fld245.subfields[0].value, "Soliloquy For Lilith /")
+        self.assertEqual(fld245.subfields[1].code, "c")
+        self.assertEqual(fld245.subfields[1].value, "Nurse With Wound.")
+        self.assertEqual(fld245.indicators, ["0", "0"])
+
+    def test_field_264(self):
+        fld264 = self.record.get("264")
+        self.assertEqual(fld264.subfields[0].code, "a")
+        self.assertEqual(
+            fld264.subfields[0].value, "[Place of publication not identified] :"
+        )
+        self.assertEqual(fld264.subfields[1].code, "b")
+        self.assertEqual(fld264.subfields[1].value, "United Dairies,")
+        self.assertEqual(fld264.subfields[2].value, "[2003]")
+
+    def test_field_300(self):
+        fld300 = self.record.get("300")
+        self.assertEqual(fld300.subfields[0].code, "a")
+        self.assertEqual(fld300.subfields[0].value, "3 audio discs :")
+        self.assertEqual(fld300.subfields[1].code, "b")
+        self.assertEqual(fld300.subfields[1].value, "digital ;")
+        self.assertEqual(fld300.subfields[2].value, "4 3/4 in.")
+
+    def test_field_500(self):
+        fld500 = self.record.get("500")
+        self.assertEqual(fld500.subfields[0].code, "a")
+        self.assertEqual(
+            fld500.subfields[0].value,
+            "Soliloquy For Lilith",
+        )
+
+    def test_field_505(self):
+        fld505 = self.record.get("505")
+        self.assertEqual(len(fld505.subfields), 8)
+        self.assertEqual(fld505.subfields[0].code, "a")
+
+    def test_field_653(self):
+        fld653 = self.record.get("653")
+        self.assertEqual(fld653.subfields[0].code, "a")
+        self.assertEqual(fld653.subfields[0].value, "Electronic")
+
+    def test_field_720(self):
+        fld720 = self.record.get("720")
+        self.assertEqual(fld720.subfields[0].code, "a")
+        self.assertEqual(fld720.subfields[0].value, "Nurse With Wound.")


### PR DESCRIPTION
Implements [SYS-1560](https://uclalibrary.atlassian.net/browse/SYS-1560)

This PR adds one new big function (`add_discogs_data()`) to `create_marc_record.py`. Given an already-parsed Discogs record and a base MARC record, this function adds MARC fields based on the [spec doc](https://docs.google.com/document/d/1RWAAhK8os6DtrhH4FcZMXlLIRjaDWkfS8pHIag6om4I/edit).

Here's an example of usage:
```
from make_music_records import *
from create_marc_record import *
worldcat_client, discogs_client, musicbrainz_client = get_clients()
discogs_records = get_discogs_records(discogs_client, search_term="5021958414720")
test_rec = discogs_records[0]
base_rec = create_base_record()
base_rec = add_local_fields(base_rec, "BARCODE","CALLNO")
discogs_rec = add_discogs_data(base_rec,test_rec)
```

This PR includes tests, with a supporting sample formatted Discogs data file. Run to see 31 tests: `docker-compose exec batchcd python -m unittest discover -s tests`

There is one (intended) difference from the specs - for field 245, in addition to the special cases for indicators for "a" and "the", I've also added one for "an" (2nd indicator 3).

[SYS-1560]: https://uclalibrary.atlassian.net/browse/SYS-1560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ