### PR TITLE
SYS-1561: add MusicBrainz data to MARC records

### DIFF
--- a/create_marc_record.py
+++ b/create_marc_record.py
@@ -151,6 +151,8 @@ def add_local_fields(record: Record, barcode: str, call_number: str) -> Record:
 
 
 def add_discogs_data(base_record: Record, data: dict) -> Record:
+    """Add metadata from a Discogs release to a MARC record. Discogs data dict
+    must be in the format returned by the DiscogsClient.parse_data method."""
     # Dates (008/07-10) - release year
     year = str(data["full_json"]["year"])  # make a string for later concatenation
     current_008 = base_record.get_fields("008")[0].data
@@ -232,7 +234,8 @@ def add_discogs_data(base_record: Record, data: dict) -> Record:
     else:
         publisher = "[publisher not identified]"
 
-    # format: [Place of publication not identified] <space> <colon>$b  LABELS\NAME <comma> $c <open square bracket>RELEASED<closed square bracket>
+    # format: [Place of publication not identified] <space> <colon>$b  LABELS\NAME <comma>
+    # $c <open square bracket>RELEASED<closed square bracket>
     subfields_264 = [
         Subfield("a", "[Place of publication not identified] :"),
         Subfield("b", publisher + ","),
@@ -298,6 +301,146 @@ def add_discogs_data(base_record: Record, data: dict) -> Record:
     # single string fields with possible multiple artists
     artist_720 = data["full_json"]["artists_sort"]
     # format: $a ARTISTS_SORT.
+    subfields_720 = [Subfield("a", artist_720 + ".")]
+    field_720 = Field(tag="720", indicators=[" ", " "], subfields=subfields_720)
+    base_record.add_ordered_field(field_720)
+
+    return base_record
+
+
+def add_musicbrainz_data(base_record: Record, data: dict) -> Record:
+    """Add metadata from a MusicBrainz release to a MARC record. MusicBrainz data dict
+    must be in the format returned by the MusicBrainzClient.parse_data method"""
+
+    # Dates (008/07-10) - DATE
+    # If no date element, leave as is
+    new_008 = base_record.get_fields("008")[0].data
+    if data["full_json"]["date"]:
+        date_008 = data["full_json"]["date"][0:4]
+        current_008 = base_record.get_fields("008")[0].data
+        new_008 = current_008[:7] + date_008 + current_008[11:]
+
+    # Lang (008/35-37) - IF [text-representation\language]=eng, THEN eng
+    # IF [text-representation\language]!=eng, THEN zxx
+    if data["full_json"]["text-representation"]["language"] == "eng":
+        new_008 = new_008[:35] + "eng" + new_008[38:]
+    else:
+        new_008 = new_008[:35] + "zxx" + new_008[38:]
+
+    base_record.remove_fields("008")
+    base_record.add_ordered_field(Field(tag="008", data=new_008))
+
+    # 024 8# $a BARCODE
+    # Normalize by removing spaces
+    barcode = data["full_json"]["barcode"].replace(" ", "")
+    subfields_024 = [Subfield("a", barcode)]
+    field_024 = Field(tag="024", indicators=["8", " "], subfields=subfields_024)
+    base_record.add_ordered_field(field_024)
+
+    # 028 02 $a LABEL-INFO\CATALOG-NUMBER $b LABEL-INFO\LABEL\NAME
+    # If no label-info\catalog-number element, do not include field.
+    # If there are multiple label-info\catalog-number elements, create multiple 028 fields.
+    for label_info in data["full_json"]["label-info-list"]:
+        subfields_028 = []
+        if label_info["catalog-number"]:
+            subfields_028.append(Subfield("a", label_info["catalog-number"]))
+            # If no label-info\label\name element, do not include $b.
+            if label_info["label"]["name"]:
+                subfields_028.append(Subfield("b", label_info["label"]["name"]))
+        field_028 = Field(tag="028", indicators=["0", "2"], subfields=subfields_028)
+        base_record.add_ordered_field(field_028)
+
+    # 245 00 $a TITLE / $c ARTIST-CREDIT\ARTIST\NAME.
+    title_245 = data["title"]
+    # first artist only
+    if "artist" in data:
+        artist_245 = data["artist"]
+        # $a Title <space> <slash> $c Artist-Credit\Artist\name <period>
+        subfields_245 = [
+            Subfield("a", title_245 + " /"),
+            Subfield("c", artist_245 + "."),
+        ]
+    else:
+        # $a Title <period>
+        subfields_245 = [Subfield("a", title_245 + ".")]
+    # if the first word of the title=”the” then 2nd indicator=4.
+    # if the first word of the title=”a” then 2nd indicator=2.
+    if title_245.lower().startswith("the "):
+        field_245 = Field(tag="245", indicators=["0", "4"], subfields=subfields_245)
+    elif title_245.lower().startswith("a "):
+        field_245 = Field(tag="245", indicators=["0", "2"], subfields=subfields_245)
+    elif title_245.lower().startswith("an "):
+        field_245 = Field(tag="245", indicators=["0", "3"], subfields=subfields_245)
+    else:
+        field_245 = Field(tag="245", indicators=["0", "0"], subfields=subfields_245)
+    base_record.add_ordered_field(field_245)
+
+    # 264 #1 $a [Place of publication not identified] : $b LABEL-INFO\LABEL\NAME, $c [DATE]
+    # For DATE - 1st 4 digits only
+    # If no label-info\label\name element, fill in $b with “[publisher not identified]”
+    # If there are multiple label-info\label\name elements, take only the first instance.
+    # If no date element, fill in $c with “[date of publication not identified]”
+    date_264 = data["full_json"]["date"][0:4]
+    if data["full_json"]["label-info-list"]:
+        label_info = data["full_json"]["label-info-list"][0]
+        if label_info["label"]["name"]:
+            publisher = label_info["label"]["name"]
+        else:
+            publisher = "[publisher not identified]"
+    else:
+        publisher = "[publisher not identified]"
+
+    # format: [Place of publication not identified] <space> <colon>
+    # $b  LABEL-INFO\LABEL\NAME <comma>
+    # $c <open square bracket>DATE<close square bracket>
+    subfields_264 = [
+        Subfield("a", "[Place of publication not identified] :"),
+        Subfield("b", publisher + ","),
+        Subfield("c", "[" + date_264 + "]"),
+    ]
+    field_264 = Field(tag="264", indicators=[" ", "1"], subfields=subfields_264)
+    base_record.add_ordered_field(field_264)
+
+    # 300 ## $a MEDIA\DISC-COUNT audio disc : $b digital ; $c 4 3/4 in.
+    # If no media\disc-count element, or if media\disc-count=0, fill in with “1.”
+    if data["full_json"]["medium-count"]:
+        qty = data["full_json"]["medium-count"]
+    # this qty is an int
+    if not qty or qty == 0:
+        qty = 1
+    if qty > 1:
+        qty_text = str(qty) + " audio discs :"
+    else:
+        qty_text = "1 audio disc :"
+
+    # format: $a MEDIA\DISC-COUNT audio disc <space> <colon>
+    # $b digital <space> <semicolon> $c 4 3/4 in.
+    subfields_300 = [
+        Subfield("a", qty_text),
+        Subfield("b", "digital ;"),
+        Subfield("c", "4 3/4 in."),
+    ]
+    field_300 = Field(tag="300", indicators=[" ", " "], subfields=subfields_300)
+    base_record.add_ordered_field(field_300)
+
+    # 500 ## $a Title from MusicBrainz database.
+    # same as 245 $a
+    subfields_500 = [Subfield("a", title_245)]
+    field_500 = Field(tag="500", indicators=[" ", " "], subfields=subfields_500)
+    base_record.add_ordered_field(field_500)
+
+    # 653 #6 $a TAGS\NAME
+    # include all tags in $a subfields
+    if data["full_json"]["tag-list"] != []:
+        subfields_653 = []
+        for tag in data["full_json"]["tag-list"]:
+            subfields_653.append(Subfield("a", tag["name"]))
+            field_653 = Field(tag="653", indicators=[" ", "6"], subfields=subfields_653)
+        base_record.add_ordered_field(field_653)
+
+    # 720 ## $a ARTIST\SORT-NAME.
+    artist_720 = data["full_json"]["artist-credit"][0]["artist"]["sort-name"]
+    # format: $a ARTIST\SORT-NAME.
     subfields_720 = [Subfield("a", artist_720 + ".")]
     field_720 = Field(tag="720", indicators=[" ", " "], subfields=subfields_720)
     base_record.add_ordered_field(field_720)

--- a/tests/sample_data/formatted_musicbrainz_sample.data
+++ b/tests/sample_data/formatted_musicbrainz_sample.data
@@ -1,0 +1,87 @@
+{
+  "title": "Soliloquy for Lilith",
+  "artist": "Nurse With Wound",
+  "publisher_number": "UD092",
+  "full_json": {
+    "id": "2565af5a-0337-383f-bad2-afbb25eb3389",
+    "ext:score": "100",
+    "title": "Soliloquy for Lilith",
+    "status": "Official",
+    "disambiguation": "gold foil",
+    "packaging": "Box",
+    "text-representation": {
+      "language": "eng",
+      "script": "Latn"
+    },
+    "artist-credit": [
+      {
+        "name": "Nurse With Wound",
+        "artist": {
+          "id": "ac18f936-0086-4bd1-a8ea-629e2c35a906",
+          "name": "Nurse With Wound",
+          "sort-name": "Nurse With Wound",
+          "disambiguation": "UK band"
+        }
+      }
+    ],
+    "release-group": {
+      "id": "f88e0e2f-50cf-3eaa-ad4c-c83a6521312c",
+      "type": "Album",
+      "title": "Soliloquy for Lilith",
+      "primary-type": "Album"
+    },
+    "date": "2003",
+    "country": "GB",
+    "release-event-list": [
+      {
+        "date": "2003",
+        "area": {
+          "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
+          "name": "United Kingdom",
+          "sort-name": "United Kingdom",
+          "iso-3166-1-code-list": [
+            "GB"
+          ]
+        }
+      }
+    ],
+    "barcode": "5021958414720",
+    "asin": "B0000CG46S",
+    "label-info-list": [
+      {
+        "catalog-number": "UD092",
+        "label": {
+          "id": "747648d6-5db9-4530-918f-86c15843497d",
+          "name": "United Dairies"
+        }
+      }
+    ],
+    "medium-list": [
+      {
+        "format": "CD",
+        "disc-list": [],
+        "disc-count": 2,
+        "track-list": [],
+        "track-count": 3
+      },
+      {
+        "format": "CD",
+        "disc-list": [],
+        "disc-count": 2,
+        "track-list": [],
+        "track-count": 3
+      },
+      {
+        "format": "CD",
+        "disc-list": [],
+        "disc-count": 1,
+        "track-list": [],
+        "track-count": 2
+      }
+    ],
+    "medium-track-count": 8,
+    "medium-count": 3,
+    "tag-list": [],
+    "artist-credit-phrase": "Nurse With Wound"
+  }
+}

--- a/tests/test_marc_creation.py
+++ b/tests/test_marc_creation.py
@@ -2,7 +2,12 @@ import unittest
 import json
 
 from pymarc import Subfield
-from create_marc_record import add_local_fields, create_base_record, add_discogs_data
+from create_marc_record import (
+    add_local_fields,
+    create_base_record,
+    add_discogs_data,
+    add_musicbrainz_data,
+)
 
 
 class TestBaseRecord(unittest.TestCase):
@@ -119,6 +124,80 @@ class TestDiscogsFields(unittest.TestCase):
         fld653 = self.record.get("653")
         self.assertEqual(fld653.subfields[0].code, "a")
         self.assertEqual(fld653.subfields[0].value, "Electronic")
+
+    def test_field_720(self):
+        fld720 = self.record.get("720")
+        self.assertEqual(fld720.subfields[0].code, "a")
+        self.assertEqual(fld720.subfields[0].value, "Nurse With Wound.")
+
+
+class TestMusicBrainzFields(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Create simulated record for use in all tests in this class.
+        base_record = create_base_record()
+        cls.record = add_local_fields(
+            base_record, barcode="FAKE BARCODE", call_number="FAKE CALL NUMBER"
+        )
+        with open("tests/sample_data/formatted_musicbrainz_sample.data") as f:
+            data = json.load(f)
+        cls.record = add_musicbrainz_data(cls.record, data)
+
+    def test_field_024(self):
+        fld024 = self.record.get("024")
+        # one barcode in the sample data
+        expected_subfields = [
+            Subfield(code="a", value="5021958414720"),
+        ]
+        self.assertEqual(fld024.subfields, expected_subfields)
+
+    def test_field_028(self):
+        fld028 = self.record.get("028")
+        self.assertEqual(fld028.subfields[0].code, "a")
+        self.assertEqual(fld028.subfields[0].value, "UD092")
+        self.assertEqual(fld028.subfields[1].code, "b")
+        self.assertEqual(fld028.subfields[1].value, "United Dairies")
+
+    def test_field_245(self):
+        fld245 = self.record.get("245")
+        self.assertEqual(fld245.subfields[0].code, "a")
+        # musicbrainz data has different capitalization than discogs
+        self.assertEqual(fld245.subfields[0].value, "Soliloquy for Lilith /")
+        self.assertEqual(fld245.subfields[1].code, "c")
+        self.assertEqual(fld245.subfields[1].value, "Nurse With Wound.")
+        self.assertEqual(fld245.indicators, ["0", "0"])
+
+    def test_field_264(self):
+        fld264 = self.record.get("264")
+        self.assertEqual(fld264.subfields[0].code, "a")
+        self.assertEqual(
+            fld264.subfields[0].value, "[Place of publication not identified] :"
+        )
+        self.assertEqual(fld264.subfields[1].code, "b")
+        self.assertEqual(fld264.subfields[1].value, "United Dairies,")
+        self.assertEqual(fld264.subfields[2].value, "[2003]")
+
+    def test_field_300(self):
+        fld300 = self.record.get("300")
+        self.assertEqual(fld300.subfields[0].code, "a")
+        self.assertEqual(fld300.subfields[0].value, "3 audio discs :")
+        self.assertEqual(fld300.subfields[1].code, "b")
+        self.assertEqual(fld300.subfields[1].value, "digital ;")
+        self.assertEqual(fld300.subfields[2].value, "4 3/4 in.")
+
+    def test_field_500(self):
+        fld500 = self.record.get("500")
+        self.assertEqual(fld500.subfields[0].code, "a")
+        # musicbrainz data has different capitalization than discogs
+        self.assertEqual(
+            fld500.subfields[0].value,
+            "Soliloquy for Lilith",
+        )
+
+    def test_field_653(self):
+        fld653 = self.record.get("653")
+        # MusicBrainz record doesn't have genre information
+        self.assertEqual(fld653, None)
 
     def test_field_720(self):
         fld720 = self.record.get("720")


### PR DESCRIPTION
Implements [SYS-1561](https://uclalibrary.atlassian.net/browse/SYS-1561)

This is the MusicBrainz equivalent of [PR #10](https://github.com/UCLALibrary/music-cd-batch/pull/10). A new function (`add_musicbrainz_data()`) adds data from MusicBrainz releases to base MARC records following the [spec doc](https://docs.google.com/document/d/1RWAAhK8os6DtrhH4FcZMXlLIRjaDWkfS8pHIag6om4I/edit).

MusicBrainz data doesn't contain track listings, so these records don't have 505s (as in the specs). Like for the Discogs records, I've added an extra case for 245 03 for titles starting with "An ". 

8 new tests are added to `test_marc_creation.py`, plus supporting sample data. There should be 39 tests in total, all passing.

[SYS-1561]: https://uclalibrary.atlassian.net/browse/SYS-1561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ