### PR TITLE
SYS-1563: Add logging and wire everything together

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,39 @@ are installed in the container.
    ```
 4. Some data sources require API keys. Get a copy of `api_keys.py` from a teammate and put it in the top level directory of the project.
 
+### Input and General Flow
+
+The program requires a tab-delimited file with one header row, with column names:
+- UPC
+- call number
+- barcode
+- title
+
+The data rows are provided by Music library staff. They transcribe the UPC and title from each CD, then add a local call number and barcode.
+
+The program searches Worldcat, Discogs, and MusicBrainz for each UPC.  If no usable Worldcat records are found via a "standard number" search by UPC,
+the program obtains catalog numbers from Discogs and MusicBrainz for the UPC and then searches Worldcat again, this time using the
+"music publisher number" index, for each catalog number found.
+
+As a sanity check, the "official" title provided for each CD by Music library staff is compared with titles from records found in the above sources.
+Worldcat records are only used when titles are similar enough, to reduce false positive matches.
+
+#### Command-line arguments
+
+```
+make_music_records.py [-h] [-s START_INDEX] [-e END_INDEX] [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}] music_data_file
+```
+
+### Output
+
+Given an input file `batch_016_20240229.tsv`, the program will generate a log file and up to two files of MARC records.
+- Log file: `batch_016_20240229.log`: Contains details about each search, evaluation of data found, and more.
+- MARC file: `batch_016_20240229_oclc.mrc`: Contains the "best" OCLC Worldcat record found (if any) for each search term.
+- MARC file: `batch_016_20240229_orig.mrc`: Contains minimal records created from Discogs or MusicBrainz data, if no usable Worldcat record was found.
+
+Log files and MARC files are appended to, if the program is run multiple times with the same input file. This allows for resuming an
+interrupted run.  Be sure there's no overlap, or MARC files could contain duplicate records.
+
 ### Testing
 
 Tests focus on code which has significant side effects or implements custom logic.

--- a/tests/test_marc_creation.py
+++ b/tests/test_marc_creation.py
@@ -117,8 +117,12 @@ class TestDiscogsFields(unittest.TestCase):
 
     def test_field_505(self):
         fld505 = self.record.get("505")
-        self.assertEqual(len(fld505.subfields), 8)
+        # All track lists go into one big 505 $a.
+        self.assertEqual(len(fld505.subfields), 1)
         self.assertEqual(fld505.subfields[0].code, "a")
+        # The sample record has 8 tracks, separated by " -- ".
+        tracks = fld505.subfields[0].value.split(" -- ")
+        self.assertEqual(len(tracks), 8)
 
     def test_field_653(self):
         fld653 = self.record.get("653")


### PR DESCRIPTION
Implements [SYS-1563](https://uclalibrary.atlassian.net/browse/SYS-1563) and more...

This PR adds logging, wires MARC creation fully into the main program, and fixes a few bugs.  Details:
* All `print` statements replaced by appropriate logging, with output going to a single log file based on the input filename.
  * `input_file.tsv` -> `input_file.log`
* MARC record creation / modification is now done.  Every row in the input file will result in one of the following:
  * The "best" acceptable Worldcat record written to `input_file_oclc.mrc`
  * If no acceptable Worldcat record, a record is created from Discogs (preferred) or Musicbrainz data and written to `input_file_orig.mrc`
  * If no usable data is found from any source, no records are created, just log messages :)
* Various utility methods added and used to replace `yymmdd` or `yyyymmdd` date strings in MARC records
* Various utility methods added to simplify multi-step MARC record creation
* Fixed and simplified MARC 505 tracklist field creation for Discogs records, along with its test
* Added `get_marc_problems()` to report on possible "use record but review later" problems with Worldcat records, based on previous project/program
* Updated `README.md` with hopefully-accurate and complete usage info

### Testing

39 automated tests, all passing.

Manual: Assuming use of `batch_016_20240229.tsv`, remove any existing logs and MARC files, as they'll be appended to by each run of the program with the same input file.
`rm batch_016_20240229.log batch_016_20240229*.mrc`

Run against a subset of the input file, like the first 15 records, which takes about 2 minutes:
`docker-compose exec batchcd python make_music_records.py -e 15 batch_016_20240229.tsv --log-level DEBUG`

Assuming the above, output should look like this:
```
13461 Apr  9 17:37 batch_016_20240229.log
33691 Apr  9 17:37 batch_016_20240229_oclc.mrc
 2948 Apr  9 17:37 batch_016_20240229_orig.mrc
```
My log file from the above has 204 lines; review and marvel at the exquisitely boring details.

I'm currently doing longer runs to look for oddities, but the above should be enough for this PR.


[SYS-1563]: https://uclalibrary.atlassian.net/browse/SYS-1563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ