### PR TITLE
SYS-1584: accommodate Discogs identifiers without descriptions

### DIFF
--- a/create_marc_record.py
+++ b/create_marc_record.py
@@ -171,7 +171,10 @@ def add_discogs_data(base_record: Record, data: dict) -> Record:
     if data["full_json"]["identifiers"]:
         for identifier in data["full_json"]["identifiers"]:
             # include only barcode elements without description: Text.
-            if identifier["type"] == "Barcode" and identifier["description"] != "Text":
+            if (
+                identifier.get("type") == "Barcode"
+                and identifier.get("description") != "Text"
+            ):
                 # Normalize by removing spaces from value
                 value = identifier["value"].replace(" ", "")
                 subfields_024 = [Subfield("a", value)]


### PR DESCRIPTION
Implements [SYS-1584](https://uclalibrary.atlassian.net/browse/SYS-1584)

Updates `add_discogs_data()` to handle situations where a release has an `identifier` without an `identifier["description"]`.

A very small fix using Python dicts' `.get()` method. This allows us to use the same conditional to determine which identifier values to use. If `identifier["description"]` does not exist, then `identifier.get("description") = None`, and `None != "Text"`. 

Though I didn't see any identifiers without a `type` value, I've made the same change there just in case.

[SYS-1584]: https://uclalibrary.atlassian.net/browse/SYS-1584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ