### PR TITLE
SYS-1585: accommodate MusicBrainz records without label-info-list or date

### DIFF
--- a/create_marc_record.py
+++ b/create_marc_record.py
@@ -316,7 +316,7 @@ def add_musicbrainz_data(base_record: Record, data: dict) -> Record:
     # Dates (008/07-10) - DATE
     # If no date element, leave as is
     new_008 = base_record.get_fields("008")[0].data
-    if data["full_json"]["date"]:
+    if "date" in data["full_json"]:
         date_008 = data["full_json"]["date"][0:4]
         current_008 = base_record.get_fields("008")[0].data
         new_008 = current_008[:7] + date_008 + current_008[11:]
@@ -341,15 +341,16 @@ def add_musicbrainz_data(base_record: Record, data: dict) -> Record:
     # 028 02 $a LABEL-INFO\CATALOG-NUMBER $b LABEL-INFO\LABEL\NAME
     # If no label-info\catalog-number element, do not include field.
     # If there are multiple label-info\catalog-number elements, create multiple 028 fields.
-    for label_info in data["full_json"]["label-info-list"]:
-        subfields_028 = []
-        if label_info["catalog-number"]:
-            subfields_028.append(Subfield("a", label_info["catalog-number"]))
-            # If no label-info\label\name element, do not include $b.
-            if label_info["label"]["name"]:
-                subfields_028.append(Subfield("b", label_info["label"]["name"]))
-        field_028 = Field(tag="028", indicators=["0", "2"], subfields=subfields_028)
-        base_record.add_ordered_field(field_028)
+    if "label-info-list" in data["full_json"]:
+        for label_info in data["full_json"]["label-info-list"]:
+            subfields_028 = []
+            if label_info["catalog-number"]:
+                subfields_028.append(Subfield("a", label_info["catalog-number"]))
+                # If no label-info\label\name element, do not include $b.
+                if label_info["label"]["name"]:
+                    subfields_028.append(Subfield("b", label_info["label"]["name"]))
+            field_028 = Field(tag="028", indicators=["0", "2"], subfields=subfields_028)
+            base_record.add_ordered_field(field_028)
 
     # 245 00 $a TITLE / $c ARTIST-CREDIT\ARTIST\NAME.
     title_245 = data["title"]
@@ -378,13 +379,16 @@ def add_musicbrainz_data(base_record: Record, data: dict) -> Record:
 
     # 264 #1 $a [Place of publication not identified] : $b LABEL-INFO\LABEL\NAME, $c [DATE]
     # For DATE - 1st 4 digits only
+    # If no date element, fill in $c with “[date of publication not identified]”
+    if "date" in data["full_json"]:
+        date_264 = data["full_json"]["date"][0:4]
+    else:
+        date_264 = "[date of publication not identified]"
     # If no label-info\label\name element, fill in $b with “[publisher not identified]”
     # If there are multiple label-info\label\name elements, take only the first instance.
-    # If no date element, fill in $c with “[date of publication not identified]”
-    date_264 = data["full_json"]["date"][0:4]
-    if data["full_json"]["label-info-list"]:
+    if "label-info-list" in data["full_json"]:
         label_info = data["full_json"]["label-info-list"][0]
-        if label_info["label"]["name"]:
+        if "name" in label_info["label"]:
             publisher = label_info["label"]["name"]
         else:
             publisher = "[publisher not identified]"

--- a/searchers/musicbrainz.py
+++ b/searchers/musicbrainz.py
@@ -35,19 +35,21 @@ class MusicbrainzClient:
 
     def parse_data(self, data: list) -> list:
         """Parse MusicBrainz list of releases to pull out data for future use.
-        Each dictionary contains title, artist, publisher_number, and full_json of the
-        original response.
+        Each dictionary contains title, artist, publisher_number (if available),
+        and full_json of the original response.
         """
         output_dict_list = []
         for release in data:
             release_dict = {
                 "title": release["title"],
                 "artist": release["artist-credit-phrase"],
-                "publisher_number": self.get_first_catalog_number(
-                    release["label-info-list"]
-                ),
                 "full_json": release,
             }
+            # Some releases have no label-info-list.
+            if "label-info-list" in release:
+                release_dict["publisher_number"] = self.get_first_catalog_number(
+                    release["label-info-list"]
+                )
             output_dict_list.append(release_dict)
         return output_dict_list
 


### PR DESCRIPTION
Implements [SYS-1585](https://uclalibrary.atlassian.net/browse/SYS-1585)

Some MusicBrainz records do not contain a `label-info-list`. This PR updates the data parsing method of the MusicBrainz client and the `add_musicbrainz_data()` MARC function to deal with this. If there is no `label-info-list`, the parsed data dict will not contain a `publisher_number`, and no 028 field will be created by `add_musicbrainz_data()`.

While working on this, I found that some MusicBrainz releases do not contain a `date` either. No changes were needed to the data parser to handle this, but `add_musicbrainz_data()` has been updated.

An example without a `label-info-list` or `date` is available with UPC `"724382900429"`. To see this one:

```
import api_keys
import make_music_records as mmr
worldcat_client, discogs_client, musicbrainz_client = mmr.get_clients()
mb_recs = mmr.get_musicbrainz_records(musicbrainz_client, "724382900429")

# not sure if these are guaranteed to always come in the same order, 
# so check that this is the one without "date" and "label-info-list"
mb_rec = mb[2]

import create_marc_record as cmr
marc_rec = cmr.create_musicbrainz_record(mb_rec)

```

[SYS-1585]: https://uclalibrary.atlassian.net/browse/SYS-1585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ