### PR TITLE
SYS-1588: add flag for CDs without cases

### DIFF
--- a/create_marc_record.py
+++ b/create_marc_record.py
@@ -109,7 +109,9 @@ def create_base_record() -> Record:
     return record
 
 
-def add_local_fields(record: Record, barcode: str, call_number: str) -> Record:
+def add_local_fields(
+    record: Record, barcode: str, call_number: str, has_cases: bool = True
+) -> Record:
     """Add local fields (0x9, 9xx) to a MARC record. These are added to all
     records, regardless of source.
     """
@@ -149,6 +151,16 @@ def add_local_fields(record: Record, barcode: str, call_number: str) -> Record:
     ]
     field_966 = Field(tag="966", indicators=[" ", " "], subfields=subfields_966)
     record.add_ordered_field(field_966)
+
+    # For disks without cases, add 590
+    # 590 ## UCLA Music Library copy lacks container insert. $9 LOCAL
+    if not has_cases:
+        subfields_590 = [
+            Subfield("a", "UCLA Music Library copy lacks container insert."),
+            Subfield("9", "LOCAL"),
+        ]
+        field_590 = Field(tag="590", indicators=[" ", " "], subfields=subfields_590)
+        record.add_ordered_field(field_590)
 
     return record
 

--- a/create_marc_record.py
+++ b/create_marc_record.py
@@ -110,7 +110,7 @@ def create_base_record() -> Record:
 
 
 def add_local_fields(
-    record: Record, barcode: str, call_number: str, has_cases: bool = True
+    record: Record, barcode: str, call_number: str, no_cases: bool = False
 ) -> Record:
     """Add local fields (0x9, 9xx) to a MARC record. These are added to all
     records, regardless of source.
@@ -154,7 +154,7 @@ def add_local_fields(
 
     # For disks without cases, add 590
     # 590 ## UCLA Music Library copy lacks container insert. $9 LOCAL
-    if not has_cases:
+    if no_cases:
         subfields_590 = [
             Subfield("a", "UCLA Music Library copy lacks container insert."),
             Subfield("9", "LOCAL"),

--- a/make_music_records.py
+++ b/make_music_records.py
@@ -50,6 +50,10 @@ def main() -> None:
         default="INFO",
         help="Set the logging level",
     )
+    # Optional flag to include 590 field in MARC records for CDs without cases.
+    # Default is that we have cases, so no 590 field is added.
+    # argparse.BooleanOptionalAction gives us --no-cases to set the flag to False.
+    parser.add_argument("--cases", action=argparse.BooleanOptionalAction)
     args = parser.parse_args()
 
     input_filename = args.music_data_file
@@ -155,7 +159,9 @@ def main() -> None:
 
         # Finally, add local fields and write the record to file, or log a message.
         if marc_record:
-            marc_record = add_local_fields(marc_record, barcode, call_number)
+            marc_record = add_local_fields(
+                marc_record, barcode, call_number, args.cases
+            )
             write_marc_record(marc_record, filename=marc_filename)
         else:
             # No suitable data at all.

--- a/make_music_records.py
+++ b/make_music_records.py
@@ -51,9 +51,8 @@ def main() -> None:
         help="Set the logging level",
     )
     # Optional flag to include 590 field in MARC records for CDs without cases.
-    # Default is that we have cases, so no 590 field is added.
-    # argparse.BooleanOptionalAction gives us --no-cases to set the flag to False.
-    parser.add_argument("--cases", action=argparse.BooleanOptionalAction)
+    # store_true means the flag is set to True if the option is present, False otherwise.
+    parser.add_argument("--no-cases", help="CDs do not have cases", action="store_true")
     args = parser.parse_args()
 
     input_filename = args.music_data_file
@@ -160,7 +159,7 @@ def main() -> None:
         # Finally, add local fields and write the record to file, or log a message.
         if marc_record:
             marc_record = add_local_fields(
-                marc_record, barcode, call_number, args.cases
+                marc_record, barcode, call_number, args.no_cases
             )
             write_marc_record(marc_record, filename=marc_filename)
         else:

--- a/tests/test_marc_creation.py
+++ b/tests/test_marc_creation.py
@@ -64,7 +64,7 @@ class TestLocalFields(unittest.TestCase):
             base_record,
             barcode="FAKE BARCODE",
             call_number="FAKE CALL NUMBER",
-            has_cases=False,
+            no_cases=True,
         )
         fld590 = record.get("590")
         self.assertEqual(fld590.subfields[0].code, "a")

--- a/tests/test_marc_creation.py
+++ b/tests/test_marc_creation.py
@@ -53,6 +53,25 @@ class TestLocalFields(unittest.TestCase):
         ]
         self.assertEqual(fld049.subfields, expected_subfields)
 
+    def test_590_with_cases(self):
+        # default test case is with cases, so we should not have a 590 field
+        fld590 = self.record.get("590")
+        self.assertEqual(fld590, None)
+
+    def test_590_without_cases(self):
+        base_record = create_base_record()
+        record = add_local_fields(
+            base_record,
+            barcode="FAKE BARCODE",
+            call_number="FAKE CALL NUMBER",
+            has_cases=False,
+        )
+        fld590 = record.get("590")
+        self.assertEqual(fld590.subfields[0].code, "a")
+        self.assertEqual(
+            fld590.subfields[0].value, "UCLA Music Library copy lacks container insert."
+        )
+
 
 class TestDiscogsFields(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
Implements [SYS-1588](https://uclalibrary.atlassian.net/browse/SYS-1588)

Adds a new optional command-line flag, `--no-cases`, indicating that a set of CDs to be processed lacks cases and should have 590 fields in each output record.

This implementation is slightly different than what was specified in the ticket. I had difficulty implementing an argument that would pick up a value of False at the command line. Instead, I've used argparse's `BooleanOptionalAction` ([documentation](https://docs.python.org/3/library/argparse.html#action)) with a new `--cases` arg that defaults to True. `BooleanOptionalAction` gives us `--no-cases` as the corresponding False arg.

There are two new tests for `create_marc_record.add_local_fields()`, covering both case cases.

Usage example:
`docker-compose exec batchcd python make_music_records.py batch_016_20240229.tsv -e 3 --no-cases`

[SYS-1588]: https://uclalibrary.atlassian.net/browse/SYS-1588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ