### PR TITLE
SYS-1591: set 500 $a to constant value for Discogs and MusicBrainz records

### DIFF
--- a/create_marc_record.py
+++ b/create_marc_record.py
@@ -284,9 +284,9 @@ def add_discogs_data(base_record: Record, data: dict) -> Record:
     field_300 = Field(tag="300", indicators=[" ", " "], subfields=subfields_300)
     base_record.add_ordered_field(field_300)
 
-    # 500 ## $a Title from Discogs database.
-    # same as 245 $a
-    subfields_500 = [Subfield("a", title_245)]
+    # 500 ## $a Record generated from Discogs database.
+    # constant value
+    subfields_500 = [Subfield("a", "Record generated from Discogs database.")]
     field_500 = Field(tag="500", indicators=[" ", " "], subfields=subfields_500)
     base_record.add_ordered_field(field_500)
 
@@ -440,9 +440,9 @@ def add_musicbrainz_data(base_record: Record, data: dict) -> Record:
     field_300 = Field(tag="300", indicators=[" ", " "], subfields=subfields_300)
     base_record.add_ordered_field(field_300)
 
-    # 500 ## $a Title from MusicBrainz database.
-    # same as 245 $a
-    subfields_500 = [Subfield("a", title_245)]
+    # 500 ## $a Record generated from MusicBrainz database.
+    # constant value
+    subfields_500 = [Subfield("a", "Record generated from MusicBrainz database.")]
     field_500 = Field(tag="500", indicators=[" ", " "], subfields=subfields_500)
     base_record.add_ordered_field(field_500)
 

--- a/tests/test_marc_creation.py
+++ b/tests/test_marc_creation.py
@@ -131,7 +131,7 @@ class TestDiscogsFields(unittest.TestCase):
         self.assertEqual(fld500.subfields[0].code, "a")
         self.assertEqual(
             fld500.subfields[0].value,
-            "Soliloquy For Lilith",
+            "Record generated from Discogs database.",
         )
 
     def test_field_505(self):
@@ -211,10 +211,9 @@ class TestMusicBrainzFields(unittest.TestCase):
     def test_field_500(self):
         fld500 = self.record.get("500")
         self.assertEqual(fld500.subfields[0].code, "a")
-        # musicbrainz data has different capitalization than discogs
         self.assertEqual(
             fld500.subfields[0].value,
-            "Soliloquy for Lilith",
+            "Record generated from MusicBrainz database.",
         )
 
     def test_field_653(self):


### PR DESCRIPTION
Implements [SYS-1591](https://uclalibrary.atlassian.net/browse/SYS-1591)

Per Hermine's email yesterday, 500 $a should contain the constant value "Record generated from Discogs database." for Discogs records. This PR makes that change (plus a corresponding one for MusicBrainz) and updates tests to match.

Automated testing: `music-cd-batch % docker-compose exec batchcd python -m unittest discover -s tests`: 41 passing tests.

Manual testing: rows 13 and 14 of the batch 16 data will use Discogs data.

[SYS-1591]: https://uclalibrary.atlassian.net/browse/SYS-1591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ