### PR TITLE
SYS-1592: Add scripts to generate OCLC number and pull lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ oclc_test
 # Exclude logs and other output
 *.log
 *.out
+*.txt
 
 # Cache files
 __pycache__

--- a/make_music_records.py
+++ b/make_music_records.py
@@ -138,22 +138,26 @@ def main() -> None:
             # Report on problems with this Worldcat record, if any;
             # these may require cataloger review, but we'll still use the record.
             marc_problems = get_marc_problems(worldcat_record)
+            if marc_problems:
+                logger.info(
+                    f"\tPull CD for review [{len(marc_problems)} MARC warning(s)]: "
+                    f"{call_number} ({official_title})"
+                )
             for problem in marc_problems:
                 logger.info(f"\t\tREVIEW: {problem}")
-
             marc_record = worldcat_record
             marc_filename = worldcat_record_filename
         elif discogs_records:
             marc_record = create_discogs_record(data=discogs_records[0])
             marc_filename = original_record_filename
             logger.info(
-                f"\tPull CD for review [original record created]: {call_number} ({official_title})"
+                f"\tPull CD for review [DC original created]: {call_number} ({official_title})"
             )
         elif musicbrainz_records:
             marc_record = create_musicbrainz_record(data=musicbrainz_records[0])
             marc_filename = original_record_filename
             logger.info(
-                f"\tPull CD for review [original record created]: {call_number} ({official_title})"
+                f"\tPull CD for review [MB original created]: {call_number} ({official_title})"
             )
 
         # Finally, add local fields and write the record to file, or log a message.

--- a/make_oclc_list.py
+++ b/make_oclc_list.py
@@ -1,0 +1,28 @@
+import argparse
+from pymarc import MARCReader
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("marc_file", help="Path to a file of MARC records")
+    args = parser.parse_args()
+    print_oclc_numbers(args.marc_file)
+
+
+def print_oclc_numbers(marc_filename: str) -> None:
+    """Prints the OCLC numbers (the digits in the 001 field) to stdout
+    for each record in a file of MARC records.
+    Assumes the records are indeed from OCLC, rather than checking the 003
+    to try to confirm that.
+    """
+    with open(marc_filename, "rb") as f:
+        reader = MARCReader(f)
+        for record in reader:
+            fld001 = record.get("001")
+            if fld001:
+                oclc_number = "".join(d for d in fld001.data if d.isdigit())
+                print(oclc_number)
+
+
+if __name__ == "__main__":
+    main()

--- a/make_pull_list.sh
+++ b/make_pull_list.sh
@@ -30,4 +30,4 @@ printf "%3d\tTotal to pull\n" ${TOTAL} >> ${PULL_LIST}
 tail -5 ${PULL_LIST}
 
 # Display MARC counts, for convenience, but don't add to the pull list
-for MRC in *.mrc; do marcsplit.exe -c ${MRC}; done
+for MRC in *.mrc; do python marc_count.py $MRC; done

--- a/make_pull_list.sh
+++ b/make_pull_list.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 logfile"
+  exit 1
+fi
+
+IN_FILE="$1"
+# Assumes logfile has a .log extension, which I've been using
+PULL_LIST=`basename ${IN_FILE} .log`_PULL.txt
+
+# Generate the full pull list
+egrep "Pull CD|REVIEW" ${IN_FILE} > ${PULL_LIST}
+
+# Add counts of specific types
+HELD_CNT=`grep "held by CLU" ${PULL_LIST} | wc -l`
+NONE_CNT=`grep "no record created" ${PULL_LIST} | wc -l`
+ORIG_CNT=`grep "original created" ${PULL_LIST} | wc -l`
+WARN_CNT=`grep "MARC warning" ${PULL_LIST} | wc -l`
+TOTAL=`expr ${HELD_CNT} + ${NONE_CNT} + ${ORIG_CNT} + ${WARN_CNT}`
+
+# Append counts to the pull list
+printf "\n" >> ${PULL_LIST}
+printf "%3d\tHeld by CLU\n" ${HELD_CNT} >> ${PULL_LIST}
+printf "%3d\tNo record created\n" ${NONE_CNT} >> ${PULL_LIST}
+printf "%3d\tOriginal record created\n" ${ORIG_CNT} >> ${PULL_LIST}
+printf "%3d\tOCLC records with warnings\n" ${WARN_CNT} >> ${PULL_LIST}
+printf "%3d\tTotal to pull\n" ${TOTAL} >> ${PULL_LIST}
+
+tail -5 ${PULL_LIST}
+
+# Display MARC counts, for convenience, but don't add to the pull list
+for MRC in *.mrc; do marcsplit.exe -c ${MRC}; done

--- a/marc_count.py
+++ b/marc_count.py
@@ -1,0 +1,24 @@
+import argparse
+from pymarc import MARCReader
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("marc_file", help="Path to a file of MARC records")
+    args = parser.parse_args()
+    marc_filename = args.marc_file
+    record_count = get_marc_record_count(marc_filename)
+    print(f"{marc_filename} contains {record_count} records.")
+
+
+def get_marc_record_count(marc_filename: str) -> int:
+    """Returns the number of records in a binary MARC file."""
+    with open(marc_filename, "rb") as f:
+        reader = MARCReader(f)
+        # MARCReader is a iterator, with no built-in support for len().
+        # Iterate over it and return the sum.
+        return sum(1 for _ in reader)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements [SYS-1592](https://uclalibrary.atlassian.net/browse/SYS-1592).

This PR adds 3 new scripts:
1. `make_oclc_list.py`: A python script which reads a file of MARC records and prints the OCLC number from each record's 001 field.  Output goes to `stdout` and should be redirected to store in a file.
2. `make_pull_list.sh`: A shell script which reads a log file generated by the main script `make_music_records.py` and creates a "pull list" Music staff can use to retrieve CDs for extra attention by catalogers.
3. `marc_count.py`: A python script which counts the MARC records in a file.  Used by `make_pull_list.sh`.

It also tweaks a few log messages in the main script to make it easier to create the pull list.

Example usage, assuming batch 16 was fully processed by the main script already:
```
$ python make_oclc_list.py batch_016_20240229_oclc.mrc > batch_016_20240229_oclcnums.txt

$ ./make_pull_list.sh batch_016_20240229.log
 11     Held by CLU
  0     No record created
 93     Original record created
 30     OCLC records with warnings
134     Total to pull
batch_016_20240229_oclc.mrc contains 504 records.
batch_016_20240229_orig.mrc contains 93 records.

$ ls -al batch*
-rw-r--r-- 1 akohler akohler  585209 Apr 16 15:47 batch_016_20240229.log
-rw-r--r-- 1 akohler akohler 1280736 Apr 16 15:47 batch_016_20240229_oclc.mrc
-rw-r--r-- 1 akohler akohler    4779 Apr 16 16:02 batch_016_20240229_oclcnums.txt
-rw-r--r-- 1 akohler akohler  120016 Apr 16 15:47 batch_016_20240229_orig.mrc
-rw-r--r-- 1 akohler akohler   13114 Apr 16 16:42 batch_016_20240229_PULL.txt
-rwxrwxrwx 1 akohler akohler   33520 Apr 11 16:16 batch_016_20240229.tsv
```

No new tests.


[SYS-1592]: https://uclalibrary.atlassian.net/browse/SYS-1592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ