### PR TITLE
SYS-1596: Various bug fixes

### DIFF
--- a/create_marc_record.py
+++ b/create_marc_record.py
@@ -269,7 +269,6 @@ def add_discogs_data(base_record: Record, data: dict) -> Record:
     # 300 ## $a FORMATS\QTY audio disc : $b digital ; $c 4 3/4 in.
     # IF FORMATS\QTY>1, THEN $a FORMATS\QTY audio discs : $b digital ; $c 4 3/4 in.
     # If no formats\qty element, or if formats\qty=0, fill in with “1.”
-
     if "formats" in data["full_json"]:
         qty = data["full_json"]["formats"][0].get("qty", "1")
     else:

--- a/make_music_records.py
+++ b/make_music_records.py
@@ -159,6 +159,9 @@ def main() -> None:
             logger.info(
                 f"\tPull CD for review [MB original created]: {call_number} ({official_title})"
             )
+        else:
+            # None of the data sources provided usable data.
+            marc_record = None
 
         # Finally, add local fields and write the record to file, or log a message.
         if marc_record:


### PR DESCRIPTION
Implements [SYS-1596](https://uclalibrary.atlassian.net/browse/SYS-1596) to fix a few bugs:
* 008/07-10 (Date1) is now set to `uuuu` (Unknown) in `create_base_record()`
* Discogs `year` values of "0" are ignored when setting 008/07-10
  * Added test case to cover this scenario
  * Discogs `year` is also only used when 4 characters long, just in case other invalid values are provided
* General 008 creation is simplified for both Discogs and MusicBrainz
  * Update `field.data` directly instead of removing and adding 008 field
  * Separate 008 updates for date and language
* Discogs 264 $c is now set correctly when provided year is "0".
  * Since 264 $c can contain any string, I did not check for any value other than "0", unlike stricter 008/07-10
* General handling of Discogs `full_json` dict keys is improved, avoiding exceptions when keys don't exist
* Slight refactoring of Discogs `qty` code to set default of 1 immediately, and avoid `qty is not defined` when that key does not exist
* Fixed bug in `make_music_records` where `marc_record` was not being set to `None` when no usable data source was found

`docker-compose exec batchcd python -m unittest discover -s tests`
43 tests, all passing.


[SYS-1596]: https://uclalibrary.atlassian.net/browse/SYS-1596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ