### PR TITLE
SYS-1604: Various fixes and improvements

### DIFF
--- a/create_marc_record.py
+++ b/create_marc_record.py
@@ -109,6 +109,27 @@ def create_base_record() -> Record:
     field_347_2 = Field(tag="347", indicators=[" ", " "], subfields=subfields_347_2)
     record.add_field(field_347_2)
 
+    # 962 ## $a cmc $b meherbatch $c YYYYMMDD $d 3 $k meherorig $9 LOCAL
+    yyyymmdd = datetime.today().strftime("%Y%m%d")
+    subfields_962 = [
+        Subfield("a", "cmc"),
+        Subfield("b", "meherbatch"),
+        Subfield("c", yyyymmdd),
+        Subfield("d", "1"),
+        Subfield("9", "LOCAL"),
+    ]
+    field_962 = Field(tag="962", indicators=[" ", " "], subfields=subfields_962)
+    record.add_ordered_field(field_962)
+
+    # 966 ## $a MEHER $b Donovan Meher Collection $9 LOCAL
+    subfields_966 = [
+        Subfield("a", "MEHER"),
+        Subfield("b", "Donovan Meher Collection"),
+        Subfield("9", "LOCAL"),
+    ]
+    field_966 = Field(tag="966", indicators=[" ", " "], subfields=subfields_966)
+    record.add_ordered_field(field_966)
+
     return record
 
 
@@ -132,27 +153,6 @@ def add_local_fields(
     subfields_099 = [Subfield("a", call_number)]
     field_099 = Field(tag="099", indicators=[" ", " "], subfields=subfields_099)
     record.add_ordered_field(field_099)
-
-    # 962 ## $a cmc $b meherbatch $c YYYYMMDD $d 3 $k meherorig $9 LOCAL
-    yyyymmdd = datetime.today().strftime("%Y%m%d")
-    subfields_962 = [
-        Subfield("a", "cmc"),
-        Subfield("b", "meherbatch"),
-        Subfield("c", yyyymmdd),
-        Subfield("d", "1"),
-        Subfield("9", "LOCAL"),
-    ]
-    field_962 = Field(tag="962", indicators=[" ", " "], subfields=subfields_962)
-    record.add_ordered_field(field_962)
-
-    # 966 ## $a MEHER $b Donovan Meher Collection $9 LOCAL
-    subfields_966 = [
-        Subfield("a", "MEHER"),
-        Subfield("b", "Donovan Meher Collection"),
-        Subfield("9", "LOCAL"),
-    ]
-    field_966 = Field(tag="966", indicators=[" ", " "], subfields=subfields_966)
-    record.add_ordered_field(field_966)
 
     # For disks without cases, add 590
     # 590 ## UCLA Music Library copy lacks container insert. $9 LOCAL

--- a/create_marc_record.py
+++ b/create_marc_record.py
@@ -215,7 +215,9 @@ def add_discogs_data(base_record: Record, data: dict) -> Record:
             catno = label.get("catno")
             name = label.get("name")
             normalized_key = normalize(catno + name)
-            labels[normalized_key] = (catno, name)
+            # Preserve the first occurrence of a key, so add only if not already present.
+            if normalized_key not in labels:
+                labels[normalized_key] = (catno, name)
 
         # Ignore keys, use now-deduped catno and name to create 028 fields.
         for normalized_key, (catno, name) in labels.items():
@@ -380,7 +382,9 @@ def add_musicbrainz_data(base_record: Record, data: dict) -> Record:
             catno = label_info.get("catalog-number")
             name = label_info.get("label", "").get("name")
             normalized_key = normalize(catno + name)
-            labels[normalized_key] = (catno, name)
+            # Preserve the first occurrence of a key, so add only if not already present.
+            if normalized_key not in labels:
+                labels[normalized_key] = (catno, name)
 
         # Ignore keys, use now-deduped catno and name to create 028 fields.
         for normalized_key, (catno, name) in labels.items():

--- a/tests/test_marc_creation.py
+++ b/tests/test_marc_creation.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import unittest
 import json
 
@@ -73,6 +74,27 @@ class TestLocalFields(unittest.TestCase):
             fld590.subfields[0].value, "UCLA Music Library copy lacks container insert."
         )
 
+    def test_962_is_added(self):
+        fld962 = self.record.get("962")
+        yyyymmdd = datetime.today().strftime("%Y%m%d")
+        expected_subfields = [
+            Subfield("a", "cmc"),
+            Subfield("b", "meherbatch"),
+            Subfield("c", yyyymmdd),
+            Subfield("d", "1"),
+            Subfield("9", "LOCAL"),
+        ]
+        self.assertEqual(fld962.subfields, expected_subfields)
+
+    def test_966_is_added(self):
+        fld966 = self.record.get("966")
+        expected_subfields = [
+            Subfield("a", "MEHER"),
+            Subfield("b", "Donovan Meher Collection"),
+            Subfield("9", "LOCAL"),
+        ]
+        self.assertEqual(fld966.subfields, expected_subfields)
+
 
 class TestDiscogsFields(unittest.TestCase):
     @classmethod
@@ -137,7 +159,7 @@ class TestDiscogsFields(unittest.TestCase):
         fake_record = self.create_fake_record()
         fld008 = fake_record.get("008")
         today_yymmdd = get_yymmdd()
-        expected_data = today_yymmdd + "suuuu    xx ||nn           n zxx d"
+        expected_data = today_yymmdd + "nuuuuuuuuxx ||nn           n zxx d"
         self.assertEqual(fld008.data, expected_data)
 
     def test_field_024(self):
@@ -222,6 +244,14 @@ class TestDiscogsFields(unittest.TestCase):
         fld720 = self.record.get("720")
         self.assertEqual(fld720.subfields[0].code, "a")
         self.assertEqual(fld720.subfields[0].value, "Nurse With Wound.")
+
+    def test_field_962_does_not_exist(self):
+        fld962 = self.record.get("962")
+        self.assertIsNone(fld962)
+
+    def test_field_966_does_not_exist(self):
+        fld966 = self.record.get("966")
+        self.assertIsNone(fld966)
 
 
 class TestMusicBrainzFields(unittest.TestCase):
@@ -355,3 +385,11 @@ class TestMusicBrainzFields(unittest.TestCase):
         fld720 = self.record.get("720")
         self.assertEqual(fld720.subfields[0].code, "a")
         self.assertEqual(fld720.subfields[0].value, "Nurse With Wound.")
+
+    def test_field_962_does_not_exist(self):
+        fld962 = self.record.get("962")
+        self.assertIsNone(fld962)
+
+    def test_field_966_does_not_exist(self):
+        fld966 = self.record.get("966")
+        self.assertIsNone(fld966)

--- a/tests/test_marc_creation.py
+++ b/tests/test_marc_creation.py
@@ -30,6 +30,27 @@ class TestBaseRecord(unittest.TestCase):
         fld344s = self.base_record.get_fields("344")
         self.assertEqual(len(fld344s), 2)
 
+    def test_962_is_added(self):
+        fld962 = self.base_record.get("962")
+        yyyymmdd = datetime.today().strftime("%Y%m%d")
+        expected_subfields = [
+            Subfield("a", "cmc"),
+            Subfield("b", "meherbatch"),
+            Subfield("c", yyyymmdd),
+            Subfield("d", "1"),
+            Subfield("9", "LOCAL"),
+        ]
+        self.assertEqual(fld962.subfields, expected_subfields)
+
+    def test_966_is_added(self):
+        fld966 = self.base_record.get("966")
+        expected_subfields = [
+            Subfield("a", "MEHER"),
+            Subfield("b", "Donovan Meher Collection"),
+            Subfield("9", "LOCAL"),
+        ]
+        self.assertEqual(fld966.subfields, expected_subfields)
+
 
 class TestLocalFields(unittest.TestCase):
     @classmethod
@@ -73,27 +94,6 @@ class TestLocalFields(unittest.TestCase):
         self.assertEqual(
             fld590.subfields[0].value, "UCLA Music Library copy lacks container insert."
         )
-
-    def test_962_is_added(self):
-        fld962 = self.record.get("962")
-        yyyymmdd = datetime.today().strftime("%Y%m%d")
-        expected_subfields = [
-            Subfield("a", "cmc"),
-            Subfield("b", "meherbatch"),
-            Subfield("c", yyyymmdd),
-            Subfield("d", "1"),
-            Subfield("9", "LOCAL"),
-        ]
-        self.assertEqual(fld962.subfields, expected_subfields)
-
-    def test_966_is_added(self):
-        fld966 = self.record.get("966")
-        expected_subfields = [
-            Subfield("a", "MEHER"),
-            Subfield("b", "Donovan Meher Collection"),
-            Subfield("9", "LOCAL"),
-        ]
-        self.assertEqual(fld966.subfields, expected_subfields)
 
 
 class TestDiscogsFields(unittest.TestCase):


### PR DESCRIPTION
Implements changes requested on [SYS-1604](https://uclalibrary.atlassian.net/browse/SYS-1604):
* 008 for original records with no date now has `008/06 = n` and `008/07-14 = uuuuuuuu` (dates are unknown)
* 024 standard identifier fields in original records are now de-duplicated
* 028 music publisher fields in original records are now de-duplicated (on $a publisher number only)
  * If multiple 028 $a $b fields normalize identically, only the first is retained, using values as supplied by data source
* 962 field contents are updated
* 962 and 966 are added to Worldcat / OCLC records only

There are 9 new tests which should cover the changes, with a total of 52 tests, all passing:
`docker-compose exec batchcd python -m unittest discover -s tests`

Real-world testing was awkward as both OCLC and original records have been fully processed in Worldcat.  I temporarily commented out code in `make_music_records.py` to work around this, then ran the program against data for several original records which previously were problems:
```
$ cat sys_1604.tsv
UPC     call number     barcode title
617026202228    CDA 37739       L0110869179     Conversion
781484102823    CDA 37813       L0110867363     Plastic Palace People Vol. 1
4988061879499   CDA 37796       L0110867223     Push The Button
775020488328    CDA 37865       L0110865144     ?
020286155225    CDA 39982       L0110751898     ¿Got Mixxx?
093624540724    CDA 38130       L0110860483     Linger Ficken' Good... And Other Barnyard Oddities
782388029025    CDA 37714       L0110869112     Revivor
796441802722    CDA 37931       L0110864642     F♯ A♯ ∞
876623000525    CDA 37822       L0110866704     Cabin In The Sky
```

I then checked the relevant fields in the records created:
```
008:240429s2000    xx ||nn           n zxx d
024:8 $a617026202228
028:02$aARCHIVE 22$bProjekt: Archive

008:240429s2011    xx ||nn           n zxx d
024:8 $a781484102823
028:02$aSTREAMLINE 1028$bStreamline

008:240429s1998    xx ||nn           n zxx d
024:8 $a4988061879499
028:02$aTFCK-87949-50$bToy's Factory
028:02$aTFCK-87949-50$bMo Wax

008:240429s2003    xx ||nn           n zxx d
024:8 $a775020488328
028:02$amwmcd001$bNot On Label (Modwheelmood Self-released)

008:240429s2011    xx ||nn           n zxx d
024:8 $a020286155225
028:02$a020286155225$b13th Planet Records
028:02$a020286155225$bMegaforce Records

008:240429s1993    xx ||nn           n zxx d
024:8 $a093624540724
028:02$a9 45407-2$bSire
028:02$a9 45407-2$bReprise Records

008:240429s2003    xx ||nn           n zxx d
028:02$aMET 290$bMetropolis

008:240429nuuuuuuuuxx ||nn           n zxx d
024:8 $a796441802722
028:02$akrank 027$bKranky

008:240429nuuuuuuuuxx ||nn           n zxx d
024:8 $a876623000525
028:02$aCBOY 1515$bCramBoy
028:02$aCBOY 1515$bCrammed Discs
```

008 fields have correct known/unknown dates; 024s are de-duplicated; 028s are de-duplicated and correct data is retained; 962 and 966 fields are not present.

I'm not thrilled about some repeated code, but I decided that keeping Discogs and MusicBrainz record creation completely separate from each other was better, overall, than refactoring some same/similar code into separate methods, especially given the relatively limited lifespan of this project.



[SYS-1604]: https://uclalibrary.atlassian.net/browse/SYS-1604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ