### PR TITLE
SYS-1723: WorldCat bug fixes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+	"image": "music-cd-batch-batchcd:latest",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"ms-python.black-formatter",
+				"ms-python.flake8"
+			]
+		}
+	},
+	"workspaceMount": "source=${localWorkspaceFolder},target=/home/batchcd/process_files,type=bind",
+	"workspaceFolder": "/home/batchcd/process_files"
+
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "devcontainer"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ oclc_test
 !tests/sample_data/*.tsv
 !tests/sample_data/*.xml
 
+# And allow devcontainer json
+!.devcontainer/*.json
+
 # Exclude logs and other output
 *.log
 *.out

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye
+FROM python:3.13-slim-bookworm
 
 RUN apt-get update
 
@@ -29,6 +29,3 @@ RUN pip install --upgrade pip --disable-pip-version-check
 
 # Install requirements for this application
 RUN pip install --no-cache-dir -r requirements.txt --user --no-warn-script-location
-
-# When container starts, keep it running indefinitely, doing nothing
-ENTRYPOINT ["tail", "-f", "/dev/null"]

--- a/README.md
+++ b/README.md
@@ -1,47 +1,55 @@
 # music-cd-batch
 Programs for Music CD batch processing
 
-## Developer Information
+# Developer Information
 
-### Overview of environment
+## Build (first time) / rebuild (as needed)
 
-The development environment requires:
-* git (at least version 2)
-* docker (current version recommended: 20.10.12)
-* docker-compose (at least version 1.25.0; current recommended: 1.29.2)
+`docker compose build`
 
-#### Docker container
+This builds a Docker image, `music-cd-batch-batchcd:latest`, which can be used for developing, testing, and running code.
 
-This uses Debian 11 (Bullseye) in a Docker container running Python 3.11.  All code
-runs in the container, so local version of Python does not matter.  All Python packages
-are installed in the container.
+## Dev container
 
-### Setup
+This project comes with a basic dev container definition, in `.devcontainer/devcontainer.json`. It's known to work with VS Code,
+and may work with other IDEs like PyCharm.  For VS Code, it also installs the Python, Black (formatter), and Flake8 (linter)
+extensions.
 
-1. Build using docker-compose.
+The project's directory is available within the container at `/home/batchcd/process_files`.
 
-   ```$ docker-compose build```
+### Rebuilding the dev container
 
-2. Bring the system up, with container running in the background.
+VS Code builds its own container from the base image. This container may not always get rebuilt when the base image is rebuilt
+(e.g., if packages are changed via `requirements.txt`).
 
-   ```$ docker-compose up -d```
+If needed, rebuild the dev container by:
+1. Close VS Code and wait several seconds for the dev container to shut down (check via `docker ps`).
+2. Delete the dev container.
+   1. `docker images | grep vsc-music` # vsc-music-cd-batch-LONG_HEX_STRING-uid
+   2. `docker image rm -f vsc-music-cd-batch-LONG_HEX_STRING-uid`
+3. Start VS Code as usual.
 
-3. Run commands in the container.
+## Running code
 
-   ```
-   # Open a shell in the container
-   $ docker-compose exec batchcd bash
+Running code from a VS Code terminal within the dev container should just work, e.g.: `python make_music_records.py` (or whatever the specific program is).
 
-   # Open a Python shell in the container
-   $ docker-compose exec batchcd python
-   
-   # Run the program against a full file of data
-   $ docker-compose exec batchcd python make_music_records.py batch_016_20240229.tsv
+Otherwise, run a program via docker compose.  From the project directory:
 
-   # Run the program against a file of data, starting with record 5 and ending with record 10
-   $ docker-compose exec batchcd python make_music_records.py -s 5 -e 10 batch_016_20240229.tsv
-   ```
-4. Some data sources require API keys. Get a copy of `api_keys.py` from a teammate and put it in the top level directory of the project.
+```
+# Open a shell in the container
+$ docker compose run batchcd bash
+
+# Open a Python shell in the container
+$ docker compose run batchcd python
+
+# Run the program against a full file of data
+$ docker compose run batchcd python make_music_records.py batch_016_20240229.tsv
+
+# Run the program against a file of data, starting with record 5 and ending with record 10
+$ docker compose run batchcd python make_music_records.py -s 5 -e 10 batch_016_20240229.tsv
+```
+
+Some data sources require API keys. Get a copy of `api_keys.py` from a teammate and put it in the top level directory of the project.
 
 ### Input and General Flow
 
@@ -81,7 +89,7 @@ interrupted run.  Be sure there's no overlap, or MARC files could contain duplic
 Tests focus on code which has significant side effects or implements custom logic.
 Run tests in the container:
 
-```$ docker-compose exec batchcd python -m unittest discover -s tests```
+```$ docker compose run batchcd python -m unittest discover -s tests```
 
 
 ## Usage (OBSOLETE: internal notes from old process, to be kept / edited later)

--- a/create_marc_record.py
+++ b/create_marc_record.py
@@ -109,6 +109,13 @@ def create_base_record() -> Record:
     field_347_2 = Field(tag="347", indicators=[" ", " "], subfields=subfields_347_2)
     record.add_field(field_347_2)
 
+    return record
+
+
+def add_worldcat_fields(record: Record) -> Record:
+    """Add local fields (9xx) to a MARC record.  These are added
+    ONLY to WorldCat records."""
+
     # 962 ## $a cmc $b meherbatch $c YYYYMMDD $d 3 $k meherorig $9 LOCAL
     yyyymmdd = datetime.today().strftime("%Y%m%d")
     subfields_962 = [
@@ -335,10 +342,6 @@ def add_discogs_data(base_record: Record, data: dict) -> Record:
     field_720 = Field(tag="720", indicators=[" ", " "], subfields=subfields_720)
     base_record.add_ordered_field(field_720)
 
-    # Remove 962 & 966, added in add_local_fields(), which apply only to OCLC records;
-    # this is safe if fields don't exist.
-    base_record.remove_fields("962", "966")
-
     return base_record
 
 
@@ -491,10 +494,6 @@ def add_musicbrainz_data(base_record: Record, data: dict) -> Record:
     subfields_720 = [Subfield("a", artist_720 + ".")]
     field_720 = Field(tag="720", indicators=[" ", " "], subfields=subfields_720)
     base_record.add_ordered_field(field_720)
-
-    # Remove 962 & 966, added in add_local_fields(), which apply only to OCLC records;
-    # this is safe if fields don't exist.
-    base_record.remove_fields("962", "966")
 
     return base_record
 

--- a/data_evaluator.py
+++ b/data_evaluator.py
@@ -107,9 +107,12 @@ def get_oclc_number(record: Record) -> str:
     """Return the OCLC number from the MARC record's 001 field, with
     alpha prefix removed.  Assumes the MARC record came from OCLC,
     which is safe for this project, so will always have an 001 with OCLC#.
+
+    This only needs to be done with OCLC numbers in MARC records.  OCLC numbers in
+    JSON data returned by WorldCat APIs are already normalized.
     """
     oclc_number = record.get("001").data
-    return "".join(d for d in oclc_number if d.isdigit())
+    return normalize_oclc_number(oclc_number)
 
 
 def get_unique_titles(
@@ -143,6 +146,18 @@ def normalize(input: str) -> str:
     """
     new_string = input.translate(str.maketrans("", "", string.whitespace))
     return strip_punctuation(new_string.upper())
+
+
+def normalize_oclc_number(input: str) -> str:
+    """Normalize OCLC number by stripping non-digits
+    and leading zeroes.
+    Examples:
+    * ocm00123456 -> 123456
+    * on98765 -> 98765
+    * 0123456789 -> 123456789
+    """
+    digits = "".join(d for d in input if d.isdigit())
+    return digits.lstrip("0")
 
 
 def title_is_close_enough(record: Record, titles: set) -> bool:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.1"
 services:
   batchcd:
     build: .

--- a/make_music_records.py
+++ b/make_music_records.py
@@ -16,6 +16,7 @@ from data_evaluator import (
 )
 from create_marc_record import (
     add_local_fields,
+    add_worldcat_fields,
     create_discogs_record,
     create_musicbrainz_record,
     write_marc_record,
@@ -145,7 +146,7 @@ def main() -> None:
                 )
             for problem in marc_problems:
                 logger.info(f"\t\tREVIEW: {problem}")
-            marc_record = worldcat_record
+            marc_record = add_worldcat_fields(worldcat_record)
             marc_filename = worldcat_record_filename
         elif discogs_records:
             marc_record = create_discogs_record(data=discogs_records[0])

--- a/tests/test_data_evaluator.py
+++ b/tests/test_data_evaluator.py
@@ -1,11 +1,13 @@
 import unittest
 
-from pymarc import Field, Record
+from pymarc import Field, MARCReader, Record
 from data_evaluator import (
     cataloging_language_is_ok,
     form_of_item_is_ok,
     get_encoding_level_score,
+    get_oclc_number,
     normalize,
+    normalize_oclc_number,
     normalize_title,
     record_is_usable,
     record_type_is_ok,
@@ -29,6 +31,20 @@ class NormalizationTests(unittest.TestCase):
         input = "Common punctuation: .,;:/-()#%&*$@!"
         normalized_input = strip_punctuation(input)
         self.assertEqual(normalized_input, "Common punctuation ")
+
+    def test_get_oclc_number(self):
+        with open("tests/sample_data/1011080915.mrc", "rb") as marc:
+            reader = MARCReader(marc)
+            # There's only 1 record in this file, so just grab it
+            # instead of messing with artificial for loop.
+            marc_record = reader.__next__()
+        oclc_number = get_oclc_number(marc_record)
+        self.assertEqual(oclc_number, "1011080915")
+
+    def test_normalize_oclc_number(self):
+        input = "ocm012345"
+        normalized_input = normalize_oclc_number(input)
+        self.assertEqual(normalized_input, "12345")
 
 
 class RecordQualityTests(unittest.TestCase):


### PR DESCRIPTION
Fixes bugs from [SYS-1723](https://uclalibrary.atlassian.net/browse/SYS-1723).  Also updates development infrastructure.

This PR fixes 2 bugs:
* Incorrect checking of OCLC holding status when OCLC number starts with leading zeroes.  These leading zeroes are now stripped before checking holding status.
* Incorrect handling of 962 and 966 fields.  These were supposed to be added to WorldCat records (only); instead, they were not being added to any records.  These fields now are added to WC records correctly.

Other changes:
* `devcontainer` configuration was added for more convenient development within the container.
* `docker` image updated to Debian 12 (bookworm) and Python 3.13
* `docker` image no longer runs perpetually via cheesy `ENTRYPOINT`.  It now starts & stops as needed via `docker compose run`, similar to our other single-container systems.
* `README.md` updated to reflect changes to development environment.

Testing:
Rebuild the base image: `docker compose build`.

Tests were added for the OCLC number normalization changes, and updated for the 962/966 field handling.  There now are 54 tests, all passing:
`docker compose run batchcd python -m unittest discover -s tests`



[SYS-1723]: https://uclalibrary.atlassian.net/browse/SYS-1723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ